### PR TITLE
allow PascalCase for case identifiers

### DIFF
--- a/UnionArgParser.Tests/UnionArgParser.Tests.fsproj
+++ b/UnionArgParser.Tests/UnionArgParser.Tests.fsproj
@@ -54,6 +54,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tests.fs" />

--- a/UnionArgParser/ArgInfo.fs
+++ b/UnionArgParser/ArgInfo.fs
@@ -76,11 +76,26 @@
     let hasCommandLineParam (aI : ArgInfo) (param : string) =
         aI.CommandLineNames |> List.exists ((=) param)
 
+    let splitName (separator:char) name =
+        string {
+            let length = String.length name
+            yield Char.ToLower name.[0]
+            for index = 1 to length - 1 do
+                let c = name.[index]
+                if c = '_' then
+                    ()
+                elif Char.IsLower c then
+                    yield c
+                else
+                    yield separator
+                    yield Char.ToLower c
+        } |> String.build
+
     let uciToOpt (uci : UnionCaseInfo) =
-        "--" + uci.Name.ToLower().Replace('_','-')
+        "--" + splitName '-' uci.Name
 
     let uciToAppConf (uci : UnionCaseInfo) =
-        uci.Name.ToLower().Replace('_',' ')
+        splitName ' ' uci.Name
 
     let getEnvArgs () =
         match System.Environment.GetCommandLineArgs() with


### PR DESCRIPTION
For command line arguments, PascalCaseParameter becomes --pascal-case-parameter,
and for App.config files, it does key="pascal case parameter".

I think it would be nicer because F# prefers PascalCaseName to Underscore_Name.
Note that this is a breaking change.
