### PR TITLE
Support use of UnionArgParser in .NET 3.5 projects.

### DIFF
--- a/UnionArgParser.sln
+++ b/UnionArgParser.sln
@@ -23,8 +23,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{AB90
 		build.fsx = build.fsx
 		build.sh = build.sh
 		RELEASE_NOTES.md = RELEASE_NOTES.md
+		syncnet35.fsx = syncnet35.fsx
 		nuget\UnionArgParser.nuspec = nuget\UnionArgParser.nuspec
 	EndProjectSection
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "UnionArgParser.Net35", "UnionArgParser\UnionArgParser.Net35.fsproj", "{434903CF-2FAA-4AC3-9916-FD24C40DCB39}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +43,10 @@ Global
 		{13BB06E0-3036-42A8-A0E1-93401AEB0DEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13BB06E0-3036-42A8-A0E1-93401AEB0DEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13BB06E0-3036-42A8-A0E1-93401AEB0DEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{434903CF-2FAA-4AC3-9916-FD24C40DCB39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{434903CF-2FAA-4AC3-9916-FD24C40DCB39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{434903CF-2FAA-4AC3-9916-FD24C40DCB39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{434903CF-2FAA-4AC3-9916-FD24C40DCB39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnionArgParser/ArgInfo.fs
+++ b/UnionArgParser/ArgInfo.fs
@@ -122,7 +122,7 @@
             mkPrimParser "float" Double.Parse
             mkPrimParser "decimal" Decimal.Parse
             mkPrimParser "bigint" System.Numerics.BigInteger.Parse
-            mkPrimParser "guid" Guid.Parse
+            mkPrimParser "guid" (fun s -> Guid(s))
         ]
 
     let primIdx = primParsers |> Seq.map (fun pp -> pp.Type, pp) |> dict

--- a/UnionArgParser/UnionArgParser.Net35.fsproj
+++ b/UnionArgParser/UnionArgParser.Net35.fsproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>434903cf-2faa-4ac3-9916-fd24c40dcb39</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>UnionArgParser.Net35</RootNamespace>
+    <AssemblyName>UnionArgParser</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>2.3.0.0</TargetFSharpCoreVersion>
+    <Name>UnionArgParser.Net35</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug.Net35\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug.Net35\UnionArgParser.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release.Net35\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release.Net35\UnionArgParser.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="assemblyInfo.fs" />
+    <Compile Include="Utils.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="ArgInfo.fs" />
+    <Compile Include="Parsers.fs" />
+    <Compile Include="UnParsers.fs" />
+    <Compile Include="UnionArgParser.fs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/build.fsx
+++ b/build.fsx
@@ -66,6 +66,15 @@ Target "Clean" (fun _ ->
     CleanDirs ["UnionArgParser/bin" ; "UnionArgParser.Tests/bin" ]
 )
 
+
+// --------------------------------------------------------------------------------------
+// Fail if our .NET35 project is not in sync with the "master" 4.0 project. 
+
+Target "CheckProjects" (fun _ ->
+    !! "./UnionArgParser/UnionArgParser.Net35.fsproj"
+    |> Fake.MSBuild.ProjectSystem.CompareProjectsTo "./UnionArgParser/UnionArgParser.fsproj"
+)
+
 //
 //// --------------------------------------------------------------------------------------
 //// Build library & test project
@@ -138,6 +147,7 @@ Target "PrepareRelease" DoNothing
 Target "All" DoNothing
 
 "Clean"
+  ==> "CheckProjects"
   ==> "RestorePackages"
   ==> "AssemblyInfo"
   ==> "Prepare"

--- a/nuget/UnionArgParser.nuspec
+++ b/nuget/UnionArgParser.nuspec
@@ -19,5 +19,8 @@
       <file src="..\UnionArgParser\bin\Release\UnionArgParser.dll" target="lib/net40" />
       <file src="..\UnionArgParser\bin\Release\UnionArgParser.xml" target="lib/net40" />
       <file src="..\UnionArgParser\bin\Release\UnionArgParser.pdb" target="lib/net40" />
+      <file src="..\UnionArgParser\bin\Release.Net35\UnionArgParser.dll" target="lib/net35" />
+      <file src="..\UnionArgParser\bin\Release.Net35\UnionArgParser.xml" target="lib/net35" />
+      <file src="..\UnionArgParser\bin\Release.Net35\UnionArgParser.pdb" target="lib/net35" />
     </files>
 </package>

--- a/syncnet35.fsx
+++ b/syncnet35.fsx
@@ -1,0 +1,12 @@
+﻿// --------------------------------------------------------------------------------------
+// FAKE script to sync the UnionArgParse.Net35 with UnionArgParser (the 4.5 build proj). 
+// --------------------------------------------------------------------------------------
+
+#I "packages/FAKE/tools"
+#r "packages/FAKE/tools/FakeLib.dll"
+
+open Fake
+open Fake.MSBuild.ProjectSystem
+
+seq { yield "./UnionArgParser/UnionArgParser.Net35.fsproj" }
+|> FixProjectFiles "./UnionArgParser/UnionArgParser.fsproj" 


### PR DESCRIPTION
- Add new project file targeting .NET 3.5 and containing same files as 4.5 proj.
- Update build script to fail if proj files are not in sync.
- Change Guid.Parse usage to ctor parse (as former .NET 4.x only).
- Update nuspec to include net35 binaries.
- Add helper fsx that can be run to sync projects.  Note: file ordering is not correct in FAKE yet so may need to tweak.  [Raised FAKE issue here](https://github.com/fsharp/FAKE/issues/454).
