### PR TITLE
Use argument union case value names in .Usage() generated documentation

### DIFF
--- a/UnionArgParser.Tests/Tests.fs
+++ b/UnionArgParser.Tests/Tests.fs
@@ -10,7 +10,7 @@
 
         type Argument =
             | Working_Directory of string
-            | Listener of string * int
+            | Listener of host:string * port:int
             | [<Mandatory>] Mandatory_Arg of bool
             | [<Rest>] Rest_Arg of int
             | Log_Level of int
@@ -22,7 +22,7 @@
                 member a.Usage =
                     match a with
                     | Working_Directory _ -> "specify a working directory."
-                    | Listener _ -> "specify a listener (hostname : port)."
+                    | Listener _ -> "specify a listener."
                     | Mandatory_Arg _ -> "a mandatory argument."
                     | Rest_Arg _ -> "an argument that consumes all remaining command line tokens."
                     | Log_Level _ -> "set the log level."
@@ -88,3 +88,9 @@
             let args = [| "--mandatory-arg" ; "true" ; "-z" |]
             let results = parser.ParseCommandLine args
             results.Contains <@ Detach @> |> should equal true
+
+        [<Test>]
+        let ``8. Usage documents explicitly named argument union case values`` () =
+            let usage = parser.Usage()
+            usage |> should contain "<host:string>"
+            usage |> should contain "<port:int>"

--- a/UnionArgParser/ArgInfo.fs
+++ b/UnionArgParser/ArgInfo.fs
@@ -29,6 +29,7 @@
             CaseCtor : obj [] -> obj
             // field tuple constructor, if not nullary case
             FieldCtor : (obj [] -> obj) option
+            FieldNames : (string list) option
 
             CommandLineNames : string list // head element denotes primary command line arg
             AppSettingsName : string option
@@ -95,6 +96,7 @@
             Usage = "display this list of options."
             AppSettingsName = None
             Parsers = [||]
+            FieldNames = None
             CaseCtor = fun _ -> invalidOp "internal error: attempting to '--help' case constructor."
             FieldCtor = None
             Hidden = false ; AppSettingsCSV = false ; Mandatory = false ; 
@@ -144,6 +146,11 @@
     let preComputeArgInfo (uci : UnionCaseInfo) : ArgInfo =
         let fields = uci.GetFields()
         let types = fields |> Array.map (fun f -> f.PropertyType)
+
+        let fieldNames =
+            if fields |> Array.forall (fun field -> field.Name.StartsWith("Item")) then None
+            else Some(fields |> Array.map (fun field -> field.Name) |> List.ofArray)
+            
         let caseCtor = FSharpValue.PreComputeUnionConstructor(uci, bindingFlags = allBindings)
 
         let dummy = 
@@ -218,6 +225,7 @@
             AppSettingsName = AppSettingsName
             Usage = dummy.Usage
             Parsers = parsers
+            FieldNames = fieldNames
             AppSettingsCSV = AppSettingsCSV
             Mandatory = mandatory
             GatherAllSources = gatherAll

--- a/UnionArgParser/UnParsers.fs
+++ b/UnionArgParser/UnParsers.fs
@@ -37,7 +37,12 @@
                             yield n
                         yield ']'
 
-                    for p in aI.Parsers -> sprintf " <%s>" p.Name
+                    let parserNames = aI.Parsers |> Seq.map (fun p -> p.Name)
+                    match aI.FieldNames with 
+                    | None -> for name in parserNames do yield sprintf " <%s>" name
+                    | Some(fieldNames) ->
+                        let names = Seq.zip fieldNames parserNames 
+                        for fieldName, parserName in names do yield (sprintf " <%s:%s>" fieldName parserName)
 
                     if aI.Rest then yield sprintf " ..."
 


### PR DESCRIPTION
I thought it would be cool if the UAP Usage() generated documentation could include names for the values provided with an argument (rather than just the type name).

For example, rather than this:

`--listener <string> <int>: specify a listener.`

I want to see this:

`--listener <host:string> <port:int>: specify a listener.`

This PR adds support for this by utilising the F# 3.1 discriminated union case field name support.  If we detect that field names have been specified, we use them.  You can see this in action in a new test, also included in the PR.

Couple of things to note:
- The test for the presence of field names will fail if someone starts all their field names with `Item`! :)  Not sure if reflection will tell us directly of their presence.  Minor, but one to check. _We could improve the test by looking for incrementing numbers when multi-value._
- I stuck the field names on the `ArgInfo` record.  It may be better on another type, but I'm not super familiar with the code base and model yet.  Let me know if you think it should be elsewhere.
- I've not check to see if there are other places this should be used outside of usage (like error messages).
