### PR TITLE
Add UseLabels attribute to specify if DU case label can be used in usage doc.

### DIFF
--- a/UnionArgParser.Tests/Tests.fs
+++ b/UnionArgParser.Tests/Tests.fs
@@ -8,14 +8,15 @@
         open NUnit.Framework
         open FsUnit
 
+        
         type Argument =
             | Working_Directory of string
-            | Listener of host:string * port:int
+            | [<UseLabels>] Listener of host:string * port:int
             | [<Mandatory>] Mandatory_Arg of bool
             | [<Rest>] Rest_Arg of int
             | Log_Level of int
             | [<AltCommandLine("-D"); AltCommandLine("-z")>] Detach
-            | [<CustomAppSettings("Foo")>] CustomAppConfig of string * int
+            | [<CustomAppSettings("Foo")>] CustomAppConfig of key:string * value:int
             | [<First>] First_Parameter of string
         with
             interface IArgParserTemplate with
@@ -90,7 +91,9 @@
             results.Contains <@ Detach @> |> should equal true
 
         [<Test>]
-        let ``8. Usage documents explicitly named argument union case values`` () =
+        let ``8. UseLabels attributed union case labels used in usage docs`` () =
             let usage = parser.Usage()
             usage |> should contain "<host:string>"
             usage |> should contain "<port:int>"
+            usage |> should not' (contain "<key:string>")
+            usage |> should not' (contain "<value:int>")

--- a/UnionArgParser/ArgInfo.fs
+++ b/UnionArgParser/ArgInfo.fs
@@ -148,8 +148,9 @@
         let types = fields |> Array.map (fun f -> f.PropertyType)
 
         let fieldNames =
-            if fields |> Array.forall (fun field -> field.Name.StartsWith("Item")) then None
-            else Some(fields |> Array.map (fun field -> field.Name) |> List.ofArray)
+            if uci.ContainsAttr<UseLabels> (true) then
+                Some(fields |> Array.map (fun field -> field.Name) |> List.ofArray)
+            else None
             
         let caseCtor = FSharpValue.PreComputeUnionConstructor(uci, bindingFlags = allBindings)
 

--- a/UnionArgParser/Types.fs
+++ b/UnionArgParser/Types.fs
@@ -45,6 +45,8 @@
     type NoAppSettingsAttribute () = inherit Attribute ()
     /// Argument can only be placed at the beginning of the command line.
     type FirstAttribute () = inherit Attribute ()
+    /// Argument value case labels can be used in the usage documenation.
+    type UseLabels () = inherit Attribute ()
 
     /// Sets a custom command line name.
     type CustomCommandLineAttribute (name : string) =


### PR DESCRIPTION
Change as per our discussion [here](https://github.com/nessos/UnionArgParser/pull/11#issuecomment-45795202).
