### PR TITLE
First mandatory special case

### DIFF
--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -310,7 +310,10 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
             let cliNames = defaultName :: altNames
 
-            for name in cliNames do validateCliParam name
+            let toValidate =
+              if uci.ContainsAttribute<FirstAttribute> () 
+                 && uci.ContainsAttribute<MandatoryAttribute> () then cliNames |> List.filter ((<>) "") else cliNames
+            for name in toValidate do validateCliParam name
 
             cliNames
 

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -49,8 +49,11 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (width : int)
         | [] -> ()
         | name :: _ ->
             yield ' '
+            let isMandatorySpecialFirst = aI.IsMandatorySpecialFirst
+            if isMandatorySpecialFirst then yield '['
             if not aI.IsMandatory then yield '['
             yield name
+            if isMandatorySpecialFirst then yield ']'
 
             match aI.ParameterInfo with
             | Primitives parsers ->
@@ -97,7 +100,10 @@ let mkArgUsage (aI : UnionCaseArgInfo) = stringExpr {
     | flags ->
         let! start = StringExpr.currentLength
         yield! StringExpr.whiteSpace switchOffset
-        yield String.concat ", " flags
+        yield String.concat ", " 
+          (if aI.IsFirst && flags |> Seq.exists ((=) "") then 
+              flags |> List.filter ((<>) "") |> List.map (sprintf "[%s]") 
+           else flags)
 
         match aI.ParameterInfo with
         | Primitives parsers ->

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -120,7 +120,8 @@ with
         match __.CustomAssignmentSeparator with
         | Some sep -> sep = separator
         | None -> false
-        
+    member inline x.IsMandatorySpecialFirst =
+      x.IsFirst && x.CommandLineNames |> Seq.exists ((=) "") && x.IsMandatory
 
 and ParameterInfo =
     | Primitives of FieldParserInfo []

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -661,6 +661,14 @@ module ``SubCommand Tests`` =
         test <@ runArgs.GetAllResults() = [ Script "test.fsx" ] @>
         
     [<Fact>]
+    let ``Test if we can parse zero arguments`` () =
+        let parser = ArgumentParser.Create<FakeArgs> "fake"
+        let args = [| |]
+        let results = parser.ParseCommandLine (args, raiseOnUsage = false)
+        ignore results
+        test <@ results.GetAllResults() = [] @>
+
+    [<Fact>]
     let ``Test if we can printf help for Fake Arguments`` () =
         let parser = ArgumentParser.Create<FakeArgs> "fake"
         let usage = parser.GetSubCommandParser(<@ Run @>).PrintUsage()


### PR DESCRIPTION
Extracted from https://github.com/fsprojects/Argu/pull/57

I added a special case for a "First" parameter if it is "Mandatory" in that case it can be assigned an empty name (which basically allows it to be used as "first" positional argument).

Ideally we would want to have a "Positional parameter" feature. But this is enough for me now (for FAKE, see https://github.com/fsharp/FAKE/pull/1281).

But now thinking about it in the special case of FAKE `fake.exe run build.fsx` I could have used an additional parameter in `run`? Would this work the same:

```
| [<CliPrefix(CliPrefix.None)>] Run of string * Argu.ParseResult<RunArgs>
```

?