### PR TITLE
Separators must have length 1

### DIFF
--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -19,7 +19,7 @@ type CliTokenReader(inputs : string[]) =
 
     static let assignmentRegex = 
         let escapedChars = new String(validSeparatorChars) |> Regex.Escape
-        new Regex(sprintf "^([%s]+)(.*)$" escapedChars, RegexOptions.Compiled)
+        new Regex(sprintf "^([%s])(.*)$" escapedChars, RegexOptions.Compiled)
 
     member __.BeginCliSegment() =
         segmentStartPos <- position

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -194,7 +194,7 @@ let validateCliParam (name : string) =
 let validSeparatorChars = [|'=' ; ':' ; '.' ; '#' ; '+' ; '^' ; '&' ; '?' ; '%' ; '$' ; '~' ; '@'|]
 let private validSeparatorRegex = 
     let escapedChars = new String(validSeparatorChars) |> Regex.Escape
-    new Regex(sprintf @"[%s]+" escapedChars, RegexOptions.Compiled)
+    new Regex(sprintf @"[%s]" escapedChars, RegexOptions.Compiled)
 
 let validateSeparator (uci : UnionCaseInfo) (sep : string) =   
     if sep = null || not <| validSeparatorRegex.IsMatch sep then


### PR DESCRIPTION
I'm having problems with relative paths (say, `--dir=../../my-relative-path`) because apparently Argu accepts any combination of any length of chars in `validSeparatorChars` as a separator. IMHO this is a bit too permissive and I cannot think of any case where this can be useful, so the simplest solution to my problem was just to edit the Regex to identify separators.

If there's fear this can break existing projects, at least this option should be configurable (either the separator length or the valid characters). This would require some more editing because at the moment `validSeparatorChars` are static, but I could do it if needed.