### PR TITLE
Add Attribute suffix to GatherUnrecognized type name

### DIFF
--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -38,7 +38,7 @@ type InheritAttribute() = inherit Attribute()
 /// Denotes that the given argument should accummulate any unrecognized arguments it encounters.
 /// Must contain a single field of type string
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type GatherUnrecognized() = inherit Attribute()
+type GatherUnrecognizedAttribute() = inherit Attribute()
 
 /// Demands that at least one subcommand is specified in the CLI; a parse exception is raised otherwise.
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -278,7 +278,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None -> None
 
     let isGatherUnrecognized =
-        if uci.ContainsAttribute<GatherUnrecognized>() then
+        if uci.ContainsAttribute<GatherUnrecognizedAttribute>() then
             match types with
             | _ when isMainCommand -> arguExn "parameter '%O' contains incompatible combination of attributes 'MainCommand' and 'GatherUnrecognized'." uci
             | [|t|] when t = typeof<string> -> true


### PR DESCRIPTION
This pull request adds the missing conventional `Attribute` suffix to the type name of the `GatherUnrecognized` attribute.

Because the suffix is optional when using an attribute, this is unproblematic for existing code that uses `GatherUnrecognized` normally. It would, however, break any code that references the type normally or accesses it via reflection, so this fix might not be applicable within this major version.