### PR TITLE
Support ConfigurationManager by default

### DIFF
--- a/src/Argu.Core/Argu.Core.fsproj
+++ b/src/Argu.Core/Argu.Core.fsproj
@@ -31,5 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.2.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Argu/ConfigReaders.fs
+++ b/src/Argu/ConfigReaders.fs
@@ -56,7 +56,6 @@ type FunctionConfigurationReader (configFunc : string -> string option, ?name : 
             | None -> null
             | Some v -> v
 
-#if !NETSTANDARD2_0
 /// AppSettings XML configuration reader
 type AppSettingsConfigurationReader () =
     interface IConfigurationReader with
@@ -80,7 +79,6 @@ type AppSettingsConfigurationFileReader private (xmlPath : string, kv : KeyValue
         fileMap.ExeConfigFilename <- path
         let config = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None)
         new AppSettingsConfigurationFileReader(path, config.AppSettings.Settings)
-#endif
 
 /// Configuration reader implementations
 type ConfigurationReader =
@@ -99,7 +97,6 @@ type ConfigurationReader =
     static member FromEnvironmentVariables() =
         new EnvironmentVariableConfigurationReader() :> IConfigurationReader
 
-#if !NETSTANDARD2_0
     /// Create a configuration reader instance using the application's resident AppSettings configuration
     static member FromAppSettings() = new AppSettingsConfigurationReader() :> IConfigurationReader
     /// Create a configuration reader instance using a local xml App.Config file
@@ -112,4 +109,3 @@ type ConfigurationReader =
             |> invalidArg assembly.FullName
 
         AppSettingsConfigurationFileReader.Create(path + ".config") :> IConfigurationReader
-#endif

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -137,7 +137,6 @@ module ``Argu Tests`` =
         test <@ results.GetResults <@ Log_Level @> = [2] @>
         test <@ results.PostProcessResult (<@ Log_Level @>, fun x -> x + 1) = 3 @>
 
-#if !NETCOREAPP2_0
     [<Fact>]
     let ``Simple AppSettings parsing`` () =
         let args = [ Mandatory_Arg true ; Detach ; Listener ("localhost", 8080) ; Log_Level 2 ] |> List.sortBy tagOf
@@ -153,7 +152,6 @@ module ``Argu Tests`` =
         test <@ results.GetResult <@ Listener @> = ("localhost", 8080) @>
         test <@ results.GetResults <@ Log_Level @> = [2] @>
         test <@ results.PostProcessResult (<@ Log_Level @>, fun x -> x + 1) = 3 @>
-#endif
 
     [<Fact>]
     let ``AppSettings CSV parsing`` () =


### PR DESCRIPTION
This addresses #95. I propose that Argu should take a dependency on `System.Configuration.ConfigurationManager` which would allow the removal of the conditional compilation directives, ergo bringing the behavior of Argu on different targets into alignment.