### PR TITLE
use SourceLink 2

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -114,9 +114,11 @@
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
       </PackageReference>
     </ItemGroup>
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -25,6 +25,10 @@ group Build
 
   nuget FAKE ~> 4.0
   nuget FSharp.Formatting
-  nuget SourceLink.Fake
   nuget xunit.runner.console ~> 2.3
   github fsharp/FAKE modules/Octokit/Octokit.fsx
+
+group SourceLink
+  storage: none
+  source https://www.nuget.org/api/v2
+  nuget SourceLink.Create.CommandLine 2.7.2 copy_local: true

--- a/paket.lock
+++ b/paket.lock
@@ -736,7 +736,6 @@ NUGET
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
     Octokit (0.28)
-    SourceLink.Fake (1.1)
     xunit.runner.console (2.3.1)
 GITHUB
   remote: fsharp/FAKE
@@ -748,3 +747,9 @@ RESTRICTION: == net40
 NUGET
   remote: https://www.nuget.org/api/v2
     FSharp.Core (3.1.2)
+
+GROUP SourceLink
+STORAGE: NONE
+NUGET
+  remote: https://www.nuget.org/api/v2
+    SourceLink.Create.CommandLine (2.7.2) - copy_local: true

--- a/src/Argu.Core/paket.references
+++ b/src/Argu.Core/paket.references
@@ -1,2 +1,4 @@
 ﻿FSharp.Core
 System.Configuration.ConfigurationManager
+group SourceLink
+  SourceLink.Create.CommandLine

--- a/src/Argu/paket.references
+++ b/src/Argu/paket.references
@@ -1,2 +1,4 @@
 ﻿group Net40
 FSharp.Core
+group SourceLink
+  SourceLink.Create.CommandLine


### PR DESCRIPTION
This switches from source indexing to source linking by updating to SourceLink 2. This pull request is part of an effort to help us track down performance issues affecting Ionide by source linking all the pdb files used by it https://github.com/fsharp/FsAutoComplete/issues/264.

The NuGet package currently looks like this. The net40 is a Windows pdb that was being source indexed, but not the netstandard2.0 one. This pull request makes it so that netstandard2.0 is source linked, but not the net40 one. My recommendation is to change the net40 over to be a portable pdb and source link it as well. This can be done easily by switching the project to be a netcore project. This should be pretty easy since you already have one. I simply didn't want to make the change as part of this pull request. You still have to have one project per TargetFramework if you want VisualStudio to work https://github.com/Microsoft/visualfsharp/issues/4084. If you don't, you can use a single project with TargetFrameworks.

```
C:\Users\camer\.nuget\packages\argu\4.1.0> tree /f
├───lib
│   ├───net40
│   │       Argu.dll
│   │       Argu.pdb
│   │       Argu.XML
│   │
│   └───netstandard2.0
│           Argu.dll
│           Argu.pdb
│           Argu.XML
```