### PR TITLE
Fixed incorrect commandline option generation in non-English locales

### DIFF
--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -28,18 +28,18 @@ let generateOptionName (uci : UnionCaseInfo) =
         | None -> CliPrefix.DoubleDash
         | Some pf -> pf.Prefix
 
-    prefixString + uci.Name.ToLower().Replace('_','-')
+    prefixString + uci.Name.ToLowerInvariant().Replace('_','-')
 
 /// Generate a CLI Param for enumeration cases
-let generateEnumName (name : string) = name.ToLower().Replace('_','-')
+let generateEnumName (name : string) = name.ToLowerInvariant().Replace('_','-')
 
 /// construct an App.Config param from UCI name
 let generateAppSettingsName (uci : UnionCaseInfo) =
-    uci.Name.ToLower().Replace('_',' ')
+    uci.Name.ToLowerInvariant().Replace('_',' ')
 
 /// construct a command identifier from UCI name
 let generateCommandName (uci : UnionCaseInfo) =
-    uci.Name.ToUpper().Replace('_', ' ')
+    uci.Name.ToUpperInvariant().Replace('_', ' ')
 
 let private defaultLabelRegex = new Regex(@"^Item[0-9]*$", RegexOptions.Compiled)
 /// Generates an argument label name from given PropertyInfo

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -201,6 +201,26 @@ module ``Argu Tests`` =
         raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "-D" |] @>
                                         (fun e -> <@ e.FirstLine.Contains "missing parameter" @>)
 
+
+    // Test the Turkish dot-less 'i', when converting the capital 'I' in the Union below this
+    // will incorrectly
+    type LocaleTurkish =
+        | Install of bool
+    with
+        interface IArgParserTemplate with
+            member a.Usage = "not tested here"
+
+    [<Fact>]
+    let ``CLIArguments Locale`` () =
+        let originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture
+        try
+            System.Threading.Thread.CurrentThread.CurrentCulture <- new System.Globalization.CultureInfo("tr-TR")
+            let parser2 = ArgumentParser.Create<LocaleTurkish> (programName = "gadget")
+            let result = parser2.ParseCommandLine([| "--install"; "true" |], ignoreMissing = true)
+            test <@ result.GetResult <@ Install @> @>
+        finally
+            System.Threading.Thread.CurrentThread.CurrentCulture <- originalCulture
+
     [<Fact>]
     let ``Unique parameter specified once`` () =
         let result = parser.ParseCommandLine([| "--unique-arg" ; "true" |], ignoreMissing = true)


### PR DESCRIPTION
This was discovered on a Turkish Windows system. In this specific case, the capital I (in "Install") within the union would be ToLower'd into a Turkish dotless 'i'. This would cause the expected '--install' to not work correctly when passed on the commandline.

For the unit test added the global locale within the Thread is modified. A try/finally is used to help ensure that it is set back to the original locale. It is assumed that tests are not run in parallel.