### PR TITLE
Optionally bypass structure checks for performance

### DIFF
--- a/docs/content/perf.fsx
+++ b/docs/content/perf.fsx
@@ -1,0 +1,65 @@
+(*** hide ***)
+// This block of code is omitted in the generated HTML documentation. Use
+// it to define helpers that you do not want to show in the documentation.
+#I "../../bin/Release/net45"
+#r "Argu.dll"
+#I "../../packages/xunit.extensibility.core/lib/netstandard1.1"
+#r "xunit.core.dll"
+
+open Argu
+open Xunit
+
+type Arguments =
+    | Argument
+with
+    interface IArgParserTemplate with
+        member __.Usage =
+            "Usage"
+
+(**
+
+# Performance Tips
+
+## Introduction
+
+Argu simplicity is achieved via Reflection and as such it's performance heavily depend on the size and depth of the
+discriminated union used.
+
+For applications that wants to get a little more performance out of Argu it's also possible to get a little more
+performance.
+
+## Bypassing structure checks
+
+By default Argu checks that the discriminated union is well formed and only contains entries that are valid.
+This incur both the cost of the checks themselves but also the cost of materializing the whole argument graph that could
+be loaded only if the corresponding arguments are used.
+
+This check can easilly be bypassed either only in release builds :
+
+*)
+
+let checkStructure =
+#if DEBUG
+    true
+#else
+    false
+#endif
+
+let parser = ArgumentParser.Create<Arguments>(checkStructure = checkStructure)
+
+(**
+
+Or always, forcing the check to happen during unit tests:
+
+*)
+
+// In the application
+module AppArgs =
+    let parser = ArgumentParser.Create<Arguments>(checkStructure = false)
+
+// In tests
+[<Fact>]
+let ``Argument structure is correct`` () =
+    ArgumentParser<Arguments>.CheckStructure()
+(**
+*)

--- a/docs/content/tutorial.fsx
+++ b/docs/content/tutorial.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin/Release/net45"
 #r "Argu.dll"
@@ -12,8 +12,8 @@ open System
 
 ## Introduction
 
-The library is based on the simple observation that 
-configuration parameters can be naturally described using discriminated unions. 
+The library is based on the simple observation that
+configuration parameters can be naturally described using discriminated unions.
 For instance:
 
 *)
@@ -26,8 +26,8 @@ type Arguments =
 
 (**
 
-Argu takes such discriminated unions and generates 
-a corresponding argument parsing scheme. 
+Argu takes such discriminated unions and generates
+a corresponding argument parsing scheme.
 For example, a parser generated from the above template would
 take the following command line input
 
@@ -80,11 +80,11 @@ with
             | Port _ -> "specify a primary port."
             | Log_Level _ -> "set the log level."
             | Detach _ -> "detach daemon from console."
- 
+
 (** We extract the argument parser from the template using the following command: *)
 
 let parser = ArgumentParser.Create<CLIArguments>(programName = "gadget.exe")
- 
+
 (** We can get the automatically generated usage string by typing *)
 
 let usage = parser.PrintUsage()
@@ -106,7 +106,7 @@ let usage = parser.PrintUsage()
         --log-level <level>   set the log level.
         --detach              detach daemon from console.
         --help                display this list of options.
- 
+
 To parse a command line input:
 
 *)
@@ -121,7 +121,7 @@ let all = results.GetAllResults() // [ Detach ; Listener ("localhost", 8080) ]
 
 ## Querying Parameters
 
-While getting a single list of all parsed results might be useful for some cases, 
+While getting a single list of all parsed results might be useful for some cases,
 it is more likely that you need to query the results for specific parameters:
 
 *)
@@ -136,12 +136,12 @@ let logLevel = results.GetResult (Log_Level, defaultValue = 0)
 
 (**
 
-Querying using quotations enables a simple and type safe way 
+Querying using quotations enables a simple and type safe way
 to deconstruct parse results into their constituent values.
 
 ## Customization
 
-The parsing behaviour of the configuration parameters 
+The parsing behaviour of the configuration parameters
 can be customized by fixing attributes to the union cases:
 
 *)
@@ -249,7 +249,7 @@ provided that these do not specify any parameters in any of their cases.
 
 ## Main commands
 
-Arguments carrying the [MainCommand](reference/argu-arguattributes-maincommandattribute.html) 
+Arguments carrying the [MainCommand](reference/argu-arguattributes-maincommandattribute.html)
 attribute can be used to specify the main set of arguments for the CLI.
 These arguments can be passed without the need to specify a switch identifier.
 
@@ -321,7 +321,7 @@ and GitArgs =
     | [<CliPrefix(CliPrefix.None)>] Commit of ParseResults<CommitArgs>
 with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | Version -> "Prints the Git suite version that the git program came from."
             | Verbose -> "Print a lot of output to stdout."
@@ -333,11 +333,11 @@ and the following console app entrypoint
 *)
 
 [<EntryPoint>]
-let main argv = 
-    try 
-    	parser.ParseCommandLine(inputs = argv, raiseOnUsage = true) |> ignore
-    with e -> 
-    	printfn "%s" e.Message
+let main argv =
+    try
+        parser.ParseCommandLine(inputs = argv, raiseOnUsage = true) |> ignore
+    with e ->
+        printfn "%s" e.Message
     0
 
 (**
@@ -369,7 +369,7 @@ and for the subcommand:
 
         --amend               Replace the tip of the current branch by creating a new commit.
         --patch, -p           Use the interactive patch selection interface to chose which changes to commit.
-        --message, -m <msg>   Use the given <msg> as the commit message. 
+        --message, -m <msg>   Use the given <msg> as the commit message.
         --help                display this list of options.
 
 This allows specifying parameters that are particular to a subcommand context.
@@ -388,8 +388,8 @@ make it to the syntax of the child subcommand. For example the command
     git clean --version
 
 will result in parse error since `Version` is not a part of the subcommand syntax,
-but one of its parent syntax. It is possible to parent options visible inside subcommands 
-by attaching the [`InheritAttribute`](http://fsprojects.github.io/Argu/reference/argu-arguattributes-inheritattribute.html) 
+but one of its parent syntax. It is possible to parent options visible inside subcommands
+by attaching the [`InheritAttribute`](http://fsprojects.github.io/Argu/reference/argu-arguattributes-inheritattribute.html)
 to switches.
 
     [lang=fsharp]
@@ -400,17 +400,17 @@ which would make the aforementioned syntax valid.
 
 ## Post Processing
 
-It should be noted here that arbitrary unions are not supported by the parser. 
-Union cases can only contain fields of primitive types. This means that user-defined 
-parsers are not supported. For configuration inputs that are non-trivial, 
+It should be noted here that arbitrary unions are not supported by the parser.
+Union cases can only contain fields of primitive types. This means that user-defined
+parsers are not supported. For configuration inputs that are non-trivial,
 a post-process facility is provided.
 *)
 
-let parsePort p = 
-    if p < 0 || p > int UInt16.MaxValue then 
+let parsePort p =
+    if p < 0 || p > int UInt16.MaxValue then
         failwith "invalid port number."
     else p
- 
+
 let ports = results.PostProcessResults (<@ Port @>, parsePort)
 
 (**
@@ -450,7 +450,7 @@ which would yield the following:
 
 ## More Examples
 
-Check out the [samples](https://github.com/fsprojects/Argu/tree/master/samples) 
+Check out the [samples](https://github.com/fsprojects/Argu/tree/master/samples)
 folder for CLI implementations that use Argu.
 
 *)

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -48,6 +48,7 @@
 
             <li class="nav-header">Documentation</li>
             <li><a href="@Root/tutorial.html">Tutorial</a></li>
+            <li><a href="@Root/perf.html">Performance Tips</a></li>
             <li><a href="@Root/reference/index.html">API Reference</a></li>
           </ul>
         </div>

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -4,7 +4,7 @@ open FSharp.Quotations
 
 /// Argument parsing result holder.
 [<Sealed; AutoSerializable(false); StructuredFormatDisplay("{StructuredFormatDisplay}")>]
-type ParseResults<'Template when 'Template :> IArgParserTemplate> 
+type ParseResults<'Template when 'Template :> IArgParserTemplate>
     internal (argInfo : UnionArgInfo, results : UnionParseResults, programName : string, description : string option, usageStringCharWidth : int, exiter : IExiter) =
 
     let mkUsageString message = mkUsageString argInfo programName true usageStringCharWidth message |> StringExpr.build
@@ -28,11 +28,11 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
         let id = expr2Uci e
         let results = results.Cases.[id.Tag]
         match Array.tryLast results with
-        | None -> 
-            let aI = argInfo.Cases.[id.Tag]
-            errorf (not aI.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." aI.Name
+        | None ->
+            let aI = argInfo.Cases.Value.[id.Tag]
+            errorf (not aI.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." aI.Name.Value
         | Some r when restrictF rs r -> r
-        | Some r -> errorf (not r.CaseInfo.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." r.CaseInfo.Name
+        | Some r -> errorf (not r.CaseInfo.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." r.CaseInfo.Name.Value
 
     let parseResult (f : 'F -> 'S) (r : UnionCaseParseResult) =
         try f (r.FieldContents :?> 'F)
@@ -61,18 +61,18 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
     /// <summary>Query parse results for parameterless argument.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template list = 
+    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template list =
         expr |> getResults source |> Seq.map (fun r -> r.Value :?> 'Template) |> Seq.toList
 
     /// <summary>Query parse results for argument with parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields list = 
+    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields list =
         expr |> getResults source |> Seq.map (fun r -> r.FieldContents :?> 'Fields) |> Seq.toList
 
     /// <summary>Gets all parse results.</summary>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetAllResults (?source : ParseSource) : 'Template list = 
+    member __.GetAllResults (?source : ParseSource) : 'Template list =
         results.Cases
         |> Seq.concat
         |> Seq.filter (restrictF source)
@@ -80,21 +80,21 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
         |> Seq.map (fun r -> r.Value :?> 'Template)
         |> Seq.toList
 
-    /// <summary>Returns the *last* specified parameter of given type, if it exists. 
+    /// <summary>Returns the *last* specified parameter of given type, if it exists.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template option = 
+    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template option =
         expr |> tryGetResult source |> Option.map (fun r -> r.Value :?> 'Template)
 
-    /// <summary>Returns the *last* specified parameter of given type, if it exists. 
+    /// <summary>Returns the *last* specified parameter of given type, if it exists.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields option = 
+    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields option =
         expr |> tryGetResult source |> Option.map (fun r -> r.FieldContents :?> 'Fields)
 
-    /// <summary>Returns the *last* specified parameter of given type. 
+    /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="defaultValue">Return this of no parameter of specific kind has been specified.</param>
@@ -103,8 +103,8 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
         match defaultValue with
         | None -> let r = getResult source expr in r.Value :?> 'Template
         | Some def -> defaultArg (s.TryGetResult(expr, ?source = source)) def
-                
-    /// <summary>Returns the *last* specified parameter of given type. 
+
+    /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="defaultValue">Return this of no parameter of specific kind has been specified.</param>
@@ -136,7 +136,7 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
     /// <param name="error">The error to be displayed.</param>
     /// <param name="errorCode">The error code to be returned.</param>
     /// <param name="showUsage">Print usage together with error message.</param>
-    member r.Raise (error : exn, ?errorCode : ErrorCode, ?showUsage : bool) : 'T = 
+    member r.Raise (error : exn, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
         r.Raise (error.Message, ?errorCode = errorCode, ?showUsage = showUsage)
 
     /// <summary>Handles any raised exception through the argument parser's exiter mechanism. Display usage optionally.</summary>
@@ -146,7 +146,7 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
     member r.Catch (f : unit -> 'T, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
         try f () with e -> r.Raise(e.Message, ?errorCode = errorCode, ?showUsage = showUsage)
 
-    /// <summary>Returns the *last* specified parameter of given type. 
+    /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.
     ///          Results are passed to a post-processing function that is error handled by the parser.
     /// </summary>
@@ -166,7 +166,7 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
     member r.PostProcessResults ([<ReflectedDefinition>] expr : Expr<'Field -> 'Template>, parser : 'Field -> 'R, ?source) : 'R list =
         expr |> getResults source |> Seq.map (parseResult parser) |> Seq.toList
 
-    /// <summary>Returns the *last* specified parameter of given type. 
+    /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.
     ///          Results are passed to a post-processing function that is error handled by the parser.
     /// </summary>
@@ -203,10 +203,10 @@ type ParseResults<'Template when 'Template :> IArgParserTemplate>
     ///     if one has been specified.
     /// </summary>
     member r.TryGetSubCommand() : 'Template option =
-        results.Cases 
-        |> Seq.concat 
-        |> Seq.tryPick(fun c -> 
-            if c.CaseInfo.Type = ArgumentType.SubCommand then
+        results.Cases
+        |> Array.concat
+        |> Array.tryPick(fun c ->
+            if c.CaseInfo.ArgumentType = ArgumentType.SubCommand then
                 Some(c.Value :?> 'Template)
             else None)
 

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -1,14 +1,11 @@
 ﻿[<AutoOpen>]
 module internal Argu.CliParser
 
-open System
-open System.Text.RegularExpressions
-
 type CliParseToken =
     | EndOfStream
     | CliParam of token:string * switch:string * caseInfo:UnionCaseArgInfo * assignment:Assignment
     | UnrecognizedOrArgument of token:string
-    | GroupedParams of token:string * switches:string[] 
+    | GroupedParams of token:string * switches:string[]
     | HelpArgument of token:string
 
 type CliTokenReader(inputs : string[]) =
@@ -28,11 +25,11 @@ type CliTokenReader(inputs : string[]) =
     member __.GetNextToken (peekOnly : bool) (argInfo : UnionArgInfo) =
         // continuation which decides how to consume parsed token
         let inline kont result =
-            if peekOnly then 
-                peekedValue <- result 
+            if peekOnly then
+                peekedValue <- result
                 isPeekedValue <- true
-            else 
-                position <- position + 1 
+            else
+                position <- position + 1
                 isPeekedValue <- false
                 peekedValue <- Unchecked.defaultof<_>
 
@@ -47,7 +44,7 @@ type CliTokenReader(inputs : string[]) =
         elif position = inputs.Length then kont EndOfStream else
 
         let token = inputs.[position]
-        
+
         match token with
         | token when argInfo.HelpParam.IsHelpFlag token -> HelpArgument token |> kont
         | token ->
@@ -66,8 +63,8 @@ type CliTokenReader(inputs : string[]) =
                 tryExtractGroupedSwitches token |> kont
 
     member __.MoveNext() =
-        if position < inputs.Length then 
-            position <- position + 1 
+        if position < inputs.Length then
+            position <- position + 1
             isPeekedValue <- false
             peekedValue <- Unchecked.defaultof<_>
 
@@ -80,7 +77,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
     let mutable lastResult : UnionCaseParseResult option = None
     let unrecognized = new ResizeArray<string>()
     let unrecognizedParseResults = new ResizeArray<obj>()
-    let results = argInfo.Cases |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult> ())
+    let results = lazy(argInfo.Cases.Value |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult> ()))
 
     member val IsUsageRequested = false with get,set
 
@@ -93,7 +90,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
             error argInfo ErrorCode.CommandLine "argument '%s' should precede all other arguments." result.ParseContext
 
         match lastResult with
-        | Some lr when not (lr.Tag = result.CaseInfo.Tag && lr.CaseInfo.IsRest) -> 
+        | Some lr when not (lr.Tag = result.CaseInfo.Tag && lr.CaseInfo.IsRest.Value) ->
             error argInfo ErrorCode.CommandLine "parameter '%s' should appear after all other arguments." lr.ParseContext
         | _ -> ()
 
@@ -101,11 +98,11 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
         if result.CaseInfo.IsMainCommand then isMainCommandDefined <- true
 
         resultCount <- resultCount + 1
-        let agg = results.[result.Tag]
-        if result.CaseInfo.IsUnique && agg.Count > 0 then
-            error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name
+        let agg = results.Value.[result.Tag]
+        if result.CaseInfo.IsUnique.Value && agg.Count > 0 then
+            error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name.Value
 
-        if result.CaseInfo.Type = ArgumentType.SubCommand then
+        if result.CaseInfo.ArgumentType = ArgumentType.SubCommand then
             isSubCommandDefined <- true
 
         agg.Add result
@@ -123,8 +120,8 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
 
     member __.AppendUnrecognized(token:string) = unrecognized.Add token
 
-    member __.ToUnionParseResults() = 
-        { Cases = results |> Array.map (fun c -> c.ToArray()) ; 
+    member __.ToUnionParseResults() =
+        { Cases = results.Value |> Array.map (fun c -> c.ToArray()) ;
           UnrecognizedCliParams = Seq.toList unrecognized ;
           UnrecognizedCliParseResults = Seq.toList unrecognizedParseResults ;
           IsUsageRequested = __.IsUsageRequested }
@@ -136,7 +133,7 @@ and CliParseResultAggregatorStack (context : UnionArgInfo) =
     let offset = context.Depth
     let stack = new ResizeArray<CliParseResultAggregator>(capacity = 2)
 
-    member self.TryDispatchResult(result : UnionCaseParseResult) =
+    member __.TryDispatchResult(result : UnionCaseParseResult) =
         if result.CaseInfo.Depth < offset then false
         else
             stack.[result.CaseInfo.Depth - offset].AppendResultInner result
@@ -170,9 +167,9 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
     | HelpArgument _ when state.RaiseOnUsage -> raise <| HelpText argInfo
     | HelpArgument _ -> aggregator.IsUsageRequested <- true
     | UnrecognizedOrArgument token ->
-        match argInfo.MainCommandParam with
-        | Some mcp when not (mcp.IsUnique && aggregator.IsMainCommandDefined) ->
-            match mcp.ParameterInfo with
+        match argInfo.MainCommandParam.Value with
+        | Some mcp when not (mcp.IsUnique.Value && aggregator.IsMainCommandDefined) ->
+            match mcp.ParameterInfo.Value with
             | Primitives parsers ->
                 // since main command syntax deals with a degree of implicitness
                 // we need a way to backtrack in case of a parse error.
@@ -180,9 +177,9 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                 // unrecognized argument resolution logic
                 let tokens = new ResizeArray<string>(5)
                 let fields = new ResizeArray<obj>(5)
-                let handleUnrecognized = 
+                let handleUnrecognized =
                     state.IgnoreUnrecognizedArgs ||
-                    Option.isSome argInfo.UnrecognizedGatherParam
+                    Option.isSome argInfo.UnrecognizedGatherParam.Value
 
                 let parseSingleParameter isFirst =
                     tokens.Clear(); fields.Clear()
@@ -197,41 +194,41 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                         match nextToken with
                         | UnrecognizedOrArgument tok ->
                             let mutable result = null
-                            let success = 
+                            let success =
                                 try result <- p.Parser tok ; true
-                                with 
+                                with
                                 | _ when handleUnrecognized -> false
                                 | _ when isFirst -> error argInfo ErrorCode.CommandLine "unrecognized argument: '%s'." token
-                                | _ -> error argInfo ErrorCode.CommandLine "parameter '%s' must be followed by <%s>, but was '%s'." 
+                                | _ -> error argInfo ErrorCode.CommandLine "parameter '%s' must be followed by <%s>, but was '%s'."
                                                     state.Reader.CurrentSegment p.Description token
 
-                            if success then 
+                            if success then
                                 tokens.Add tok ; fields.Add result
                                 if not isFirst then state.Reader.MoveNext()
                                 aux (i + 1)
 
                         | CliParam(_, token, _, _)
-                        | HelpArgument token 
-                        | GroupedParams(token,_) -> 
+                        | HelpArgument token
+                        | GroupedParams(token,_) ->
                             if not handleUnrecognized then
                                 error argInfo ErrorCode.CommandLine "parameter '%s' must be followed by <%s>, but was '%s'." state.Reader.CurrentSegment p.Description token
                         | _ ->
-                            if not handleUnrecognized then 
+                            if not handleUnrecognized then
                                 error argInfo ErrorCode.CommandLine "argument '%s' must be followed by <%s>." state.Reader.CurrentSegment p.Description
 
                     do aux 0
                     if fields.Count = parsers.Length then
-                        aggregator.AppendResult mcp mcp.Name (fields.ToArray())
+                        aggregator.AppendResult mcp mcp.Name.Value (fields.ToArray())
                         true
                     else
-                        match argInfo.UnrecognizedGatherParam with
+                        match argInfo.UnrecognizedGatherParam.Value with
                         | Some ugp -> for tok in tokens do aggregator.AppendResult ugp token [|tok|]
                         | None when state.IgnoreUnrecognizedArgs -> for tok in tokens do aggregator.AppendUnrecognized tok
                         | None -> arguExn "internal error in main command parser."
 
                         false
 
-                if parseSingleParameter true && mcp.IsRest then
+                if parseSingleParameter true && mcp.IsRest.Value then
                     while not state.Reader.IsCompleted && parseSingleParameter false do ()
 
             | ListParam(existential, field) ->
@@ -252,7 +249,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                                     if not isFirst then state.Reader.MoveNext()
                                     gather false
                                 elif isFirst then
-                                    match argInfo.UnrecognizedGatherParam with
+                                    match argInfo.UnrecognizedGatherParam.Value with
                                     | Some ugp -> aggregator.AppendResult ugp token [|token|]
                                     | None when state.IgnoreUnrecognizedArgs -> aggregator.AppendUnrecognized token
                                     | None -> error argInfo ErrorCode.CommandLine "unrecognized argument: '%s'." token
@@ -261,13 +258,13 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                         do gather true
                         match Seq.toList args with
                         | [] -> () ; false
-                        | list -> aggregator.AppendResult mcp mcp.Name [| list |] ; true }
+                        | list -> aggregator.AppendResult mcp mcp.Name.Value [| list |] ; true }
 
             | paramInfo -> arguExn "internal error. MainCommand has param representation %A" paramInfo
 
         | _ ->
 
-        match argInfo.UnrecognizedGatherParam with
+        match argInfo.UnrecognizedGatherParam.Value with
         | Some ugp -> aggregator.AppendResult ugp token [|token|]
         | None when state.IgnoreUnrecognizedArgs -> aggregator.AppendUnrecognized token
         | None -> error argInfo ErrorCode.CommandLine "unrecognized argument: '%s'." token
@@ -275,7 +272,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
     | GroupedParams(_, switches) ->
         for sw in switches do
             let caseInfo = argInfo.CliParamIndex.Value.[sw]
-            match caseInfo.ParameterInfo with
+            match caseInfo.ParameterInfo.Value with
             | Primitives [||] -> aggregator.AppendResult caseInfo sw [||]
             | OptionalParam _ -> aggregator.AppendResult caseInfo sw [|None|]
             | _ -> error argInfo ErrorCode.CommandLine "argument '%s' cannot be grouped with other switches." sw
@@ -284,12 +281,12 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
         error argInfo ErrorCode.CommandLine "invalid CLI syntax '%s%s<param>'." name sep
 
     | CliParam(token, name, caseInfo, assignment) ->
-        match caseInfo.ParameterInfo with
+        match caseInfo.ParameterInfo.Value with
         | Primitives [|field|] when caseInfo.IsCustomAssignment ->
             match assignment with
             | NoAssignment -> error argInfo ErrorCode.CommandLine "argument '%s' missing an assignment." name
             | Assignment(_,_,eqp) ->
-                let argument = 
+                let argument =
                     try field.Parser eqp
                     with _ -> error argInfo ErrorCode.CommandLine "argument '%s' is assigned invalid value, should be <%s>." token field.Description
 
@@ -300,11 +297,11 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
             | UnrecognizedOrArgument token ->
                 match caseInfo.AssignmentParser.Value token with
                 | Assignment(key,_,value) ->
-                    let k = 
+                    let k =
                         try kf.Parser key
                         with _ -> error argInfo ErrorCode.CommandLine "argument '%s' was given invalid key '%s', should be <%s>." state.Reader.CurrentSegment token kf.Description
 
-                    let v = 
+                    let v =
                         try vf.Parser value
                         with _ -> error argInfo ErrorCode.CommandLine "argument '%s' was given invalid value assignment '%s', should be <%s>." state.Reader.CurrentSegment token vf.Description
 
@@ -312,15 +309,15 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                     state.Reader.MoveNext()
 
                 | NoAssignment ->
-                    error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'." 
-                        caseInfo.Name kf.Description caseInfo.CustomAssignmentSeparator.Value vf.Description
+                    error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'."
+                        caseInfo.Name.Value kf.Description caseInfo.CustomAssignmentSeparator.Value.Value vf.Description
 
-            | CliParam(token,name,_,Assignment _) -> 
-                error argInfo ErrorCode.CommandLine "argument '%s' was given invalid key name '%s' in '%s'." 
+            | CliParam(token,name,_,Assignment _) ->
+                error argInfo ErrorCode.CommandLine "argument '%s' was given invalid key name '%s' in '%s'."
                     state.Reader.CurrentSegment name token
             | _ ->
-                error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'." 
-                    caseInfo.Name kf.Description caseInfo.CustomAssignmentSeparator.Value vf.Description
+                error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'."
+                    caseInfo.Name.Value kf.Description caseInfo.CustomAssignmentSeparator.Value.Value vf.Description
 
         | Primitives fields ->
             let parseNextField (p : FieldParserInfo) =
@@ -334,29 +331,29 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                     result
 
                 | CliParam(_, name, _, _)
-                | HelpArgument name 
+                | HelpArgument name
                 | GroupedParams(name,_) -> error argInfo ErrorCode.CommandLine "parameter '%s' must be followed by <%s>, but was '%s'." state.Reader.CurrentSegment p.Description name
                 | _ -> error argInfo ErrorCode.CommandLine "argument '%s' must be followed by <%s>." state.Reader.CurrentSegment p.Description
-                        
+
             let parseSingleParameter () =
                 let fields = fields |> Array.map parseNextField
                 aggregator.AppendResult caseInfo name fields
 
             parseSingleParameter ()
-            if caseInfo.IsRest then
+            if caseInfo.IsRest.Value then
                 while not state.Reader.IsCompleted do
                     parseSingleParameter ()
 
         | OptionalParam(existential, field) when caseInfo.IsCustomAssignment ->
-            let optArgument = existential.Accept { new IFunc<obj> with 
+            let optArgument = existential.Accept { new IFunc<obj> with
                 member __.Invoke<'T> () =
                     match assignment with
                     | NoAssignment -> Option<'T>.None :> obj
-                    | Assignment(_,_,eqp) -> 
-                        let argument = 
+                    | Assignment(_,_,eqp) ->
+                        let argument =
                             try field.Parser eqp
-                            with _ -> 
-                                error argInfo ErrorCode.CommandLine "argument '%s' is assigned invalid value, should be <%s>." 
+                            with _ ->
+                                error argInfo ErrorCode.CommandLine "argument '%s' is assigned invalid value, should be <%s>."
                                     token field.Description
 
                         argument :?> 'T |> Some :> obj }
@@ -367,7 +364,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
             let optArgument = existential.Accept { new IFunc<obj> with
                 member __.Invoke<'T> () =
                     match state.Reader.GetNextToken true argInfo with
-                    | UnrecognizedOrArgument tok -> 
+                    | UnrecognizedOrArgument tok ->
                         let argument = try Some(field.Parser tok :?> 'T) with _ -> None
                         match argument with Some _ -> state.Reader.MoveNext() | None -> ()
                         argument :> obj
@@ -399,7 +396,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
         | SubCommand (existential, nestedUnion, _) ->
             let nestedResults = parseCommandLineInner state nestedUnion
-            let result = 
+            let result =
                 existential.Accept { new ITemplateFunc<obj> with
                     member __.Invoke<'Template when 'Template :> IArgParserTemplate> () =
                         new ParseResults<'Template>(nestedUnion, nestedResults, state.ProgramName, state.Description, state.UsageStringCharWidth, state.Exiter) :> obj }
@@ -409,14 +406,14 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 and private parseCommandLineInner (state : CliParseState) (argInfo : UnionArgInfo) =
     let results = state.ResultStack.CreateNextAggregator argInfo
     while not state.Reader.IsCompleted do parseCommandLinePartial state argInfo results
-    if argInfo.IsRequiredSubcommand && not results.IsSubCommandDefined then
+    if not results.IsSubCommandDefined && argInfo.IsRequiredSubcommand.Value then
         error argInfo ErrorCode.CommandLine "no valid subcommand has been specified."
     results.ToUnionParseResults()
 
 /// <summary>
 ///     Parse the entire command line
 /// </summary>
-and parseCommandLine (argInfo : UnionArgInfo) (programName : string) (description : string option) (width : int) (exiter : IExiter) 
+and parseCommandLine (argInfo : UnionArgInfo) (programName : string) (description : string option) (width : int) (exiter : IExiter)
                         (raiseOnUsage : bool) (ignoreUnrecognized : bool) (inputs : string []) =
     let state = {
         Reader = new CliTokenReader(inputs)

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -21,22 +21,22 @@ let mkUnionCase (info : UnionCaseArgInfo) index parseSource parsecontext (fields
 
 /// Create a ParseResults<_> instance from a set of template parameters
 let mkParseResultFromValues (info : UnionArgInfo) (exiter : IExiter) (width : int)
-                            (programName : string) (description : string option) 
+                            (programName : string) (description : string option)
                             (values : seq<'Template>) =
 
-    let agg = info.Cases |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult>())
+    let agg = info.Cases.Value |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult>())
     let mutable i = 0
     for value in values do
         let value = value :> obj
         let tag = info.TagReader.Value value
-        let case = info.Cases.[tag]
+        let case = info.Cases.Value.[tag]
         let fields = case.FieldReader.Value value
-        let result = mkUnionCase case i ParseSource.None case.Name fields
+        let result = mkUnionCase case i ParseSource.None case.Name.Value fields
         agg.[tag].Add result
         i <- i + 1
 
-    let results = 
-        { 
+    let results =
+        {
             IsUsageRequested = false
             UnrecognizedCliParams = []
             UnrecognizedCliParseResults = []
@@ -62,17 +62,17 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             match acr, clr with
             | Choice1Of2 ts, [||] -> ts
             | Choice2Of2 e, [||] -> raise e
-            | Choice2Of2 e, _ when caseInfo.GatherAllSources -> raise e
-            | Choice1Of2 ts, ts' when caseInfo.GatherAllSources -> Array.append ts ts'
+            | Choice2Of2 e, _ when caseInfo.GatherAllSources.Value -> raise e
+            | Choice1Of2 ts, ts' when caseInfo.GatherAllSources.Value -> Array.append ts ts'
             | _, ts' -> ts'
 
         match combined with
-        | [||] when caseInfo.IsMandatory && not ignoreMissingMandatory -> 
-            error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name
+        | [||] when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
+            error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value
         | _ -> combined
 
     {
-        Cases = argInfo.Cases |> Array.map combineSingle
+        Cases = argInfo.Cases.Value |> Array.map combineSingle
         UnrecognizedCliParams = match commandLineResults with Some clr -> clr.UnrecognizedCliParams | None -> []
         UnrecognizedCliParseResults = match commandLineResults with Some clr -> clr.UnrecognizedCliParseResults | None -> []
         IsUsageRequested = commandLineResults |> Option.exists (fun r -> r.IsUsageRequested)

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -69,7 +69,7 @@ let private dict (s: ('key * 'value) []) =
     let result = System.Collections.Generic.Dictionary<'key, 'value>(s.Length)
     for pair in s do
         result.Add(fst pair, snd pair)
-    result :> System.Collections.Generic.IDictionary<_,_>
+    result
 
 let primitiveParsers = lazy(
     let mkParser name (pars : string -> 'a) unpars = typeof<'a>, mkPrimitiveParser name pars unpars in

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -218,7 +218,7 @@ module Helpers =
                 |> Seq.append helpParam.Flags
                 |> Seq.filter (fun name -> name.Length = 2 && name.[0] = '-' && Char.IsLetterOrDigit name.[1])
                 |> Seq.map (fun name -> name.[1])
-                |> System.Linq.Enumerable.Distinct
+                |> Seq.distinct
                 |> Seq.toArray
                 |> String
 

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -20,7 +20,7 @@ module CliPrefix =
 
 /// Source from which to parse arguments
 [<Flags>]
-type ParseSource = 
+type ParseSource =
     | None          = 0
     | AppSettings   = 1
     | CommandLine   = 2
@@ -75,7 +75,7 @@ type ProcessExiter(colorizerOption : (ErrorCode -> ConsoleColor option) option) 
     // Note: this ctor is required to preserve binary compatibility with < 3.7
     new () = ProcessExiter(None)
     new (colorizer : (ErrorCode -> ConsoleColor option)) = ProcessExiter(Some colorizer)
-    
+
     interface IExiter with
         member __.Name = "Process Exiter"
         member __.Exit(msg : string, errorCode : ErrorCode) =
@@ -103,19 +103,19 @@ type ArgumentType =
 type ArgumentCaseInfo =
     {
         /// Human readable name identifier
-        Name : string
+        Name : Lazy<string>
         /// Union case reflection identifier
         UnionCaseInfo : UnionCaseInfo
         /// Type of argument parser
         ArgumentType : ArgumentType
 
         /// head element denotes primary command line arg
-        CommandLineNames : string list
+        CommandLineNames : Lazy<string list>
         /// name used in AppSettings
-        AppSettingsName : string option
+        AppSettingsName : Lazy<string option>
 
         /// Description of the parameter
-        Description : string
+        Description : Lazy<string>
 
         /// AppSettings parameter separator
         AppSettingsSeparators : string list
@@ -123,23 +123,23 @@ type ArgumentCaseInfo =
         AppSettingsSplitOptions : StringSplitOptions
 
         /// Mandated Cli position for the argument
-        CliPosition : CliPosition
+        CliPosition : Lazy<CliPosition>
         /// Specifies that this argument is the main CLI command
         IsMainCommand : bool
         /// If specified, should consume remaining tokens from the CLI
-        IsRest : bool
+        IsRest : Lazy<bool>
         /// Separator token used for EqualsAssignment syntax; e.g. '=' forces '--param=arg' syntax
-        CustomAssignmentSeparator : string option
+        CustomAssignmentSeparator : Lazy<string option>
         /// If specified, multiple parameters can be added in AppSettings in CSV form.
-        AppSettingsCSV : bool
+        AppSettingsCSV : Lazy<bool>
         /// Fails if no argument of this type is specified
-        IsMandatory : bool
+        IsMandatory : Lazy<bool>
         /// Specifies that argument should be specified at most once in CLI
-        IsUnique : bool
+        IsUnique : Lazy<bool>
         /// Hide from Usage
-        IsHidden : bool
+        IsHidden : Lazy<bool>
         /// Declares that the parameter should gather any unrecognized CLI params
-        IsGatherUnrecognized : bool
+        IsGatherUnrecognized : Lazy<bool>
         /// Combine AppSettings with CLI inputs
-        GatherAllSources : bool
+        GatherAllSources : Lazy<bool>
     }

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -2,13 +2,8 @@
 module internal Argu.UnionArgInfo
 
 open System
-open System.IO
 open System.Collections.Generic
-open System.Reflection
-
 open FSharp.Reflection
-open FSharp.Quotations
-open FSharp.Quotations.Patterns
 
 type IParseResult =
     abstract GetAllResults : unit -> seq<obj>
@@ -47,44 +42,49 @@ type HelpParam =
     }
 with
     member inline hp.IsHelpFlag(flag : string) =
-        let rec aux = function 
-            | [] -> false 
+        let rec aux = function
+            | [] -> false
             | h :: tl' -> if h = flag then true else aux tl'
 
         aux hp.Flags
-        
+
 /// Represents a parsing schema for a single parameter
 [<NoEquality; NoComparison>]
 type UnionCaseArgInfo =
     {
         /// Human readable name identifier
-        Name : string
+        Name : Lazy<string>
         /// Contextual depth of current argument w.r.t subcommands
         Depth : int
         /// Numbers of parameters in the given union case
         Arity : int
+        /// Same as UnionCaseInfo.Tag
+        Tag: int
         /// UCI identifier
-        UnionCaseInfo : UnionCaseInfo
+        UnionCaseInfo : Lazy<UnionCaseInfo>
         /// Field parser definitions or nested union argument
-        ParameterInfo : ParameterInfo
+        ParameterInfo : Lazy<ParameterInfo>
+
+        /// Type of argument in ParameterInfo
+        ArgumentType : ArgumentType
 
         /// Gets the parent record for union case
         GetParent : unit -> UnionArgInfo
 
         /// Builds a union case out of its field parameters
-        CaseCtor : obj [] -> obj
+        CaseCtor : Lazy<obj [] -> obj>
         /// Composes case fields into a parametric tuple, if not nullary
         FieldCtor : Lazy<obj [] -> obj>
         /// Decomposes a case instance into an array of fields
         FieldReader : Lazy<obj -> obj[]>
 
         /// head element denotes primary command line arg
-        CommandLineNames : string list
+        CommandLineNames : Lazy<string list>
         /// name used in AppSettings
-        AppSettingsName : string option
+        AppSettingsName : Lazy<string option>
 
         /// Description of the parameter
-        Description : string
+        Description : Lazy<string>
 
         /// Configuration parsing parameter separator
         AppSettingsSeparators : string []
@@ -92,38 +92,35 @@ type UnionCaseArgInfo =
         AppSettingsSplitOptions : StringSplitOptions
 
         /// Separator token used for EqualsAssignment syntax; e.g. '=' forces '--param=arg' syntax
-        CustomAssignmentSeparator : string option
+        CustomAssignmentSeparator : Lazy<string option>
         /// Reads assignment for that specific value
         AssignmentParser : Lazy<string -> Assignment>
 
         /// Mandated Cli position for the argument
-        CliPosition : CliPosition
+        CliPosition : Lazy<CliPosition>
         /// Specifies that this argument is the main CLI command
-        MainCommandName : string option
+        MainCommandName : Lazy<string option>
         /// If specified, should consume remaining tokens from the CLI
-        IsRest : bool
+        IsRest : Lazy<bool>
         /// If specified, multiple parameters can be added in Configuration in CSV form.
-        AppSettingsCSV : bool
+        AppSettingsCSV : Lazy<bool>
         /// Fails if no argument of this type is specified
-        IsMandatory : bool
+        IsMandatory : Lazy<bool>
         /// Indicates that argument should be inherited in the scope of any sibling subcommands.
-        IsInherited : bool
+        IsInherited : Lazy<bool>
         /// Specifies that argument should be specified at most once in CLI
-        IsUnique : bool
+        IsUnique : Lazy<bool>
         /// Hide from Usage
-        IsHidden : bool
+        IsHidden : Lazy<bool>
         /// Declares that the parameter should gather any unrecognized CLI params
-        IsGatherUnrecognized : bool
+        IsGatherUnrecognized : Lazy<bool>
         /// Combine AppSettings with CLI inputs
-        GatherAllSources : bool
+        GatherAllSources : Lazy<bool>
     }
 with
-    member inline __.Tag = __.UnionCaseInfo.Tag
-    member inline __.IsMainCommand = Option.isSome __.MainCommandName
-    member inline __.IsCommandLineArg = match __.CommandLineNames with [] -> __.IsMainCommand | _ -> true
-    member inline __.Type = __.ParameterInfo.Type
-    member inline __.IsCustomAssignment = Option.isSome __.CustomAssignmentSeparator
-        
+    member inline __.IsMainCommand = Option.isSome __.MainCommandName.Value
+    member inline __.IsCommandLineArg = match __.CommandLineNames.Value with [] -> __.IsMainCommand | _ -> true
+    member inline __.IsCustomAssignment = Option.isSome __.CustomAssignmentSeparator.Value
 
 and ParameterInfo =
     | Primitives of FieldParserInfo []
@@ -142,23 +139,25 @@ and [<NoEquality; NoComparison>]
   UnionArgInfo =
     {
         /// Union Case Argument Info
-        Type : Type
+        Type : Lazy<Type>
         /// Contextual depth of current argument w.r.t subcommands
         Depth : int
         /// If subcommand, attempt to retrieve the parent record
         TryGetParent : unit -> UnionCaseArgInfo option
         /// Union cases
-        Cases : UnionCaseArgInfo []
+        Cases : Lazy<UnionCaseArgInfo []>
         /// Help flags specified by the library
         HelpParam : HelpParam
         /// Denotes that the current argument contains subcommands
-        ContainsSubcommands : bool
+        ContainsSubcommands : Lazy<bool>
         /// Specifies that CLI parse results require a subcommand
-        IsRequiredSubcommand : bool
+        IsRequiredSubcommand : Lazy<bool>
         /// Precomputed union tag reader
         TagReader : Lazy<obj -> int>
         /// Arguments inherited by parent commands
         InheritedParams : Lazy<UnionCaseArgInfo []>
+        /// Single character switches (Regex)
+        GroupedSwitchRegex : Lazy<string option>
         /// Single character switches
         GroupedSwitchExtractor : Lazy<string -> string []>
         /// Union cases indexed by appsettings parameter names
@@ -166,14 +165,13 @@ and [<NoEquality; NoComparison>]
         /// Union cases indexed by cli parameter names
         CliParamIndex : Lazy<PrefixDictionary<UnionCaseArgInfo>>
         /// Union case parameter used to gather unrecognized CLI params
-        UnrecognizedGatherParam : UnionCaseArgInfo option
+        UnrecognizedGatherParam : Lazy<UnionCaseArgInfo option>
         /// Main command parameter used by the CLI syntax
-        MainCommandParam : UnionCaseArgInfo option
+        MainCommandParam : Lazy<UnionCaseArgInfo option>
     }
 with
     member inline uai.UsesHelpParam = List.isEmpty uai.HelpParam.Flags |> not
-    member inline uai.ContainsMainCommand = Option.isSome uai.MainCommandParam
-
+    member inline uai.ContainsMainCommand = Option.isSome uai.MainCommandParam.Value
 
 [<NoEquality; NoComparison>]
 type UnionCaseParseResult =
@@ -186,12 +184,12 @@ type UnionCaseParseResult =
         CaseInfo : UnionCaseArgInfo
         /// metadata provided by the parser
         ParseContext : string
-        /// parse source 
+        /// parse source
         Source : ParseSource
     }
 with
     member inline __.Tag = __.CaseInfo.Tag
-    member inline __.Value = __.CaseInfo.CaseCtor __.Fields
+    member inline __.Value = __.CaseInfo.CaseCtor.Value __.Fields
     member inline __.FieldContents = __.CaseInfo.FieldCtor.Value __.Fields
 
 [<NoEquality; NoComparison>]
@@ -208,14 +206,14 @@ type UnionParseResults =
     }
 
 type UnionCaseArgInfo with
-    member inline ucai.IsFirst = ucai.CliPosition = CliPosition.First
-    member inline ucai.IsLast = ucai.CliPosition = CliPosition.Last
+    member inline ucai.IsFirst = ucai.CliPosition.Value = CliPosition.First
+    member inline ucai.IsLast = ucai.CliPosition.Value = CliPosition.Last
 
     member ucai.ToArgumentCaseInfo() : ArgumentCaseInfo =
         {
             Name = ucai.Name
-            ArgumentType = ucai.Type
-            UnionCaseInfo = ucai.UnionCaseInfo
+            ArgumentType = ucai.ArgumentType
+            UnionCaseInfo = ucai.UnionCaseInfo.Value
             CommandLineNames = ucai.CommandLineNames
             AppSettingsName = ucai.AppSettingsName
             Description = ucai.Description

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -161,7 +161,7 @@ and [<NoEquality; NoComparison>]
         /// Single character switches
         GroupedSwitchExtractor : Lazy<string -> string []>
         /// Union cases indexed by appsettings parameter names
-        AppSettingsParamIndex : Lazy<IDictionary<string, UnionCaseArgInfo>>
+        AppSettingsParamIndex : Lazy<Dictionary<string, UnionCaseArgInfo>>
         /// Union cases indexed by cli parameter names
         CliParamIndex : Lazy<PrefixDictionary<UnionCaseArgInfo>>
         /// Union case parameter used to gather unrecognized CLI params


### PR DESCRIPTION
* Move lot of things to `Lazy<T>`
* Allow to bypass the checks that would force all theses lazy to materialize (Because the discriminated union structure is checked)
* Add a performance tips page to the docs
* Other small optimizations

**Note**: Some optimizations and additional fields (Like the addition of `GroupedSwitchRegex`) can seem to make no sense. They are here to pave the way for the next optimization that will allow to serialize the whole `UnionArgInfo` structure and loading it instead of computing it. The corresponding WIP branch can be found here : https://github.com/vbfox/Argu/tree/perf