### PR TITLE
Avoid attributes recomputation

### DIFF
--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -458,12 +458,12 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | [] when isMainCommand.Value ->
             match parsers.Value with
             | Primitives ps ->
-                let name = ps |> Seq.map (fun p -> sprintf "<%s>" p.Description) |> String.concat " "
+                let name = ps |> Seq.map (fun p -> "<" + p.Description + ">" ) |> String.concat " "
                 if isRest.Value then name + "..." else name
-            | ListParam(_,p) -> sprintf "<%s>..." p.Description
-            | _ -> arguExn "internal error in argu parser representation %O." uci
+            | ListParam(_,p) -> "<" + p.Description + ">..."
+            | _ -> raise <| new ArguException("internal error in argu parser representation " + (uci.ToString()) + ".")
         | _ when Option.isSome appSettingsName.Value -> appSettingsName.Value.Value
-        | _ -> arguExn "parameter '%O' needs to have at least one parse source." uci)
+        | _ -> raise <| new ArguException("parameter '" + (uci.ToString()) + "' needs to have at least one parse source."))
 
     let fieldReader = Helpers.fieldReader uci
     let fieldCtor = Helpers.tupleConstructor types

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -433,8 +433,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
                 yield!
                     attributes.Value
-                    |> Array.filter (fun x -> x :? AltCommandLineAttribute)
-                    |> Array.collect(fun x -> (x :?> AltCommandLineAttribute).Names)
+                    |> Array.collect(function | :? AltCommandLineAttribute as a -> a.Names | _ -> [||])
             ]
 
             for name in cliNames do validateCliParam name

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -137,40 +137,6 @@ type IDictionary<'K,'V> with
 
 let currentProgramName = lazy(System.Diagnostics.Process.GetCurrentProcess().MainModule.ModuleName)
 
-type UnionCaseInfo with
-    member uci.GetAttributes<'T when 'T :> Attribute> (?includeDeclaringTypeAttrs : bool) =
-        let includeDeclaringTypeAttrs = defaultArg includeDeclaringTypeAttrs false
-
-        let caseAttrs = uci.GetCustomAttributes typeof<'T> |> Seq.cast<Attribute>
-        let attrs =
-            if includeDeclaringTypeAttrs then
-                uci.DeclaringType.GetCustomAttributes(typeof<'T>, false)
-                |> Seq.cast<Attribute>
-                |> Seq.append caseAttrs
-            else
-                caseAttrs
-
-        attrs |> Seq.map (fun o -> o :?> 'T)
-
-    member uci.TryGetAttribute<'T when 'T :> Attribute> (?includeDeclaringTypeAttrs : bool) =
-        let includeDeclaringTypeAttrs = defaultArg includeDeclaringTypeAttrs false
-
-        match uci.GetCustomAttributes typeof<'T> with
-        | [||] when includeDeclaringTypeAttrs ->
-            match uci.DeclaringType.GetCustomAttributes(typeof<'T>, false) |> Seq.toArray with
-            | [||] -> None
-            | attrs -> Some (attrs.[0] :?> 'T)
-        | [||] -> None
-        | attrs -> Some (attrs.[0] :?> 'T)
-
-    member uci.ContainsAttribute<'T when 'T :> Attribute> (?includeDeclaringTypeAttrs : bool) =
-        let includeDeclaringTypeAttrs = defaultArg includeDeclaringTypeAttrs false
-        if uci.GetCustomAttributes typeof<'T> |> Array.isEmpty |> not then true
-        elif includeDeclaringTypeAttrs then
-            uci.DeclaringType.GetCustomAttributes(typeof<'T>, false) |> Seq.isEmpty |> not
-        else
-            false
-
 /// recognize exprs that strictly contain DU constructors
 /// e.g. <@ Case @> is valid but <@ fun x y -> Case y x @> is invalid
 let expr2Uci (e : Expr) =


### PR DESCRIPTION
Here is another performance PR.

The main performance gain is the removal of repeated calls to `GetAttributes` and instead doing a single `GetAttributes` and reusing the values.

I also removed some usage of printf as building the printers take time and it's not very necessary here.

Performance looks like that:

| Method |              Args | BypassDependencyGraphChecks |     Mean |    Error |    StdDev |
|------- |------------------ |---------------------------- |---------:|---------:|----------:|
|  **Parse** | **add nuget Foo.Bar** |                       **False** | **323.0 ms** | **2.000 ms** |  **4.041 ms** |
|  **Parse** | **add nuget Foo.Bar** |                        **True** | **205.3 ms** | **3.239 ms** |  **6.543 ms** |
|  **Parse** |           **install** |                       **False** | **314.0 ms** | **3.090 ms** |  **6.243 ms** |
|  **Parse** |           **install** |                        **True** | **179.4 ms** | **1.554 ms** |  **3.139 ms** |
|  **Parse** |           **restore** |                       **False** | **317.9 ms** | **7.365 ms** | **14.877 ms** |
|  **Parse** |           **restore** |                        **True** | **179.4 ms** | **2.066 ms** |  **4.173 ms** |

It can be compared to https://github.com/fsprojects/Argu/pull/105#issuecomment-370914390 so the gain is of ~35% with structure check and ~10% without.

And from that point we're fast enough that https://github.com/Microsoft/visualfsharp/pull/4465 will gain 40% for checked and 50% for no checks, bringing the no check version of **add nuget Foo.Bar** around 150ms :

![k flamegraph1](https://user-images.githubusercontent.com/131878/37260266-56ae3b88-2591-11e8-89e9-b0f2a349cdc8.png)
