### PR TITLE
case-insensitivity for command-line enums

### DIFF
--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -36,6 +36,9 @@ let getDefaultHelpParam (t : Type) =
 
     prefixString + defaultHelpParam
 
+/// Generate a CLI Param for enumeration cases
+let generateEnumName (name : string) = name.ToLowerInvariant().Replace('_','-')
+
 /// construct a CLI param from UCI name
 let generateOptionName (uci : UnionCaseInfo) (attributes: obj[]) (declaringTypeAttributes: obj[])=
     let prefixString =
@@ -43,10 +46,7 @@ let generateOptionName (uci : UnionCaseInfo) (attributes: obj[]) (declaringTypeA
         | None -> CliPrefix.DoubleDash
         | Some pf -> pf.Prefix
 
-    prefixString + uci.Name.ToLowerInvariant().Replace('_','-')
-
-/// Generate a CLI Param for enumeration cases
-let generateEnumName (name : string) = name.ToLowerInvariant().Replace('_','-')
+    prefixString + (generateEnumName uci.Name)
 
 /// construct an App.Config param from UCI name
 let generateAppSettingsName (uci : UnionCaseInfo) =
@@ -121,7 +121,7 @@ let tryGetEnumerationParser label (t : Type) =
     let name = names |> String.concat "|"
 
     let parser (text : string) =
-        let text = text.Trim()
+        let text = text.Trim() |> generateEnumName
         let _,value = index |> Array.find (fun (id,_) -> text = id)
         value
 
@@ -160,7 +160,7 @@ let tryGetDuEnumerationParser label (t : Type) =
     let name = index |> Seq.map fst |> String.concat "|"
 
     let parser (text : string) =
-        let text = text.Trim()
+        let text = text.Trim() |> generateEnumName
         let _,value = index |> Array.find (fun (id,_) -> text = id)
         value
 

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -465,6 +465,11 @@ module ``Argu Tests`` =
         test <@ result.GetResult <@ Enum @> = Enum.Second @>
 
     [<Fact>]
+    let ``Enumeration parameter parsing (case-insensitive, allowing original case)`` () =
+        let result = parser.Parse([|"--enum" ; "Third" ; "--mandatory-arg" ; "true"|])
+        test <@ result.GetResult <@ Enum @> = Enum.Third @>
+
+    [<Fact>]
     let ``Enumeration parameter should fail on unsupported values`` () =
         raisesWith<ArguParseException> <@ parser.Parse([|"--enum" ; "first,second" ; "--mandatory-arg" ; "true"|]) @>
                                         (fun e -> <@ e.FirstLine.Contains "first|second|third" @>)
@@ -473,6 +478,11 @@ module ``Argu Tests`` =
     let ``F# Enumeration parameter parsing`` () =
         let result = parser.Parse([|"--enumeration=second" ; "--mandatory-arg" ; "true"|])
         test <@ result.GetResult <@ Enumeration @> = Some Second @>
+
+    [<Fact>]
+    let ``F# Enumeration parameter parsing (case-insensitive, allowing original case)`` () =
+        let result = parser.Parse([|"--enumeration=Third" ; "--mandatory-arg" ; "true"|])
+        test <@ result.GetResult <@ Enumeration @> = Some Third @>
 
     [<Fact>]
     let ``F# Enumeration parameter should fail on unsupported values`` () =


### PR DESCRIPTION
Allows the use of the original case of the Enum/DU as well as the lower-case-only.  e.g. 'Third' and 'third'.  (Of course, it also allows any case-mix as well -- e.g. 'tHird' -- but that seems acceptable.)