### PR TITLE
chain exception from reflection

### DIFF
--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -484,7 +484,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     // extract the description string for given union case
     let description = lazy(
         try dummy.Value.Usage
-        with _ -> arguExn "Error generating usage string from IArgParserTemplate for case %O." uci)
+        with exn -> arguExnChain exn "Error generating usage string from IArgParserTemplate for case %O." uci)
 
     let uai = {
         Tag = uci.Tag

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -40,8 +40,9 @@ type CliPosition =
     | Last          = 3
 
 /// Exception raised by Argu
-type ArguException internal (message : string) =
-    inherit Exception(message)
+type ArguException internal (message : string, exn : Exception) =
+    inherit Exception(message, exn)
+    new(message) = ArguException(message, null)
 
 /// Parse exception raised by Argu
 type ArguParseException internal (message : string, errorCode : ErrorCode) =

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -16,6 +16,8 @@ let allBindings = BindingFlags.NonPublic ||| BindingFlags.Public ||| BindingFlag
 
 let inline arguExn fmt = Printf.ksprintf(fun msg -> raise <| new ArguException(msg)) fmt
 
+let inline arguExnChain exn fmt = Printf.ksprintf(fun msg -> raise <| new ArguException(msg, exn)) fmt
+
 /// get CL arguments from environment
 let getEnvironmentCommandLineArgs () =
     match System.Environment.GetCommandLineArgs() with


### PR DESCRIPTION
This chains the inner exceptions so that we see what types to add for reflection to work with CoreRT.

Before:
```
PS C:\Users\taggac\github\corert-fsharp-example> .\bin\Release\netcoreapp2.2\win-x64\native\littleClient.exe
Unhandled Exception: Argu.ArguException: Error generating usage string from IArgParserTemplate for case LsArguments.Block_Size.
   at Argu.PreCompute.description@487-1.Invoke(String) + 0x34
   at Argu.PreCompute.description@485.Invoke(Unit) + 0xc1
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xdd
   at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x52
   at System.Lazy`1.CreateValue() + 0x84
   at Argu.PreCompute.postProcess@629.Invoke(UnionArgInfo.UnionArgInfo) + 0x301
   at <StartupCode$Argu>.$ArgumentParser.-cctor@87-1.Invoke(Unit) + 0x5b
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xdd
   at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x52
   at System.Lazy`1.CreateValue() + 0x84
   at Argu.ArgumentParser`1..ctor(FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1) + 0xee
   at Argu.ArgumentParser.Create[Template](FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1) + 0x4e
   at Argu.Samples.LS.Main.main(String[]) + 0x8e
   at littleClient!<BaseAddress>+0x656d79
```

After:
```
PS C:\Users\taggac\github\corert-fsharp-example> .\bin\Release\netcoreapp2.2\win-x64\native\littleClient.exe
Unhandled Exception: Argu.ArguException: Error generating usage string from IArgParserTemplate for case LsArguments.Block_Size. ---> System.Reflection.MissingMetadataException: 'Argu.Utils.Existential<Argu.Samples.LS.Size>' is missing metadata. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=392859
   at System.Reflection.Runtime.TypeInfos.RuntimeConstructedGenericTypeInfo.ConstructedGenericTypeTable.Factory(RuntimeConstructedGenericTypeInfo.UnificationKey) + 0x13d
   at System.Collections.Concurrent.ConcurrentUnifierWKeyed`2.GetOrAdd(K) + 0x8d
   at System.Reflection.Runtime.TypeInfos.RuntimeConstructedGenericTypeInfo.GetRuntimeConstructedGenericTypeInfo(RuntimeTypeInfo, RuntimeTypeInfo[], RuntimeTypeHandle) + 0x46
   at Argu.Utils.Existential.FromType(Type) + 0x4d
   at Argu.Utils.Unchecked.UntypedDefaultOf(Type) + 0x20
   at Argu.PreCompute.dummy@291.Invoke(Unit) + 0x4f
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xdd
   at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x52
   at System.Lazy`1.CreateValue() + 0x84
   at Argu.PreCompute.description@485.Invoke(Unit) + 0x24

   --- End of inner exception stack trace ---
   at Argu.PreCompute.description@487-1.Invoke(String) + 0x33
   at Argu.PreCompute.description@485.Invoke(Unit) + 0xca
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xdd
   at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x52
   at System.Lazy`1.CreateValue() + 0x84
   at Argu.PreCompute.postProcess@629.Invoke(UnionArgInfo.UnionArgInfo) + 0x301
   at <StartupCode$Argu>.$ArgumentParser.-cctor@87-1.Invoke(Unit) + 0x5b
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xdd
   at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x52
   at System.Lazy`1.CreateValue() + 0x84
   at Argu.ArgumentParser`1..ctor(FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1) + 0xee
   at Argu.ArgumentParser.Create[Template](FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1, FSharpOption`1) + 0x4e
   at Argu.Samples.LS.Main.main(String[]) + 0x8e
   at littleClient!<BaseAddress>+0x656b29
```