### PR TITLE
Corrects index.fs.

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -75,7 +75,7 @@ of an application's configuration file:
     </appSettings>
 
 Furthermore, you can parse environment variables, by supplying the an `EnvironmentVariableReader` to the `Parse` call:
-**)
+*)
 
 let argv = [| "--log-level"; "3" |]
 let reader = EnvironmentVariableConfigurationReader() :> IConfigurationReader
@@ -83,7 +83,7 @@ let parser =  ArgumentParser.Create<Arguments>(programName = "rutta")
 // pass the reader to the Parse call
 let results = parser.Parse(argv, configurationReader=reader)
 
-(*
+(**
 ## Who uses Argu?
 
   * [MBrace](http://m-brace.net/)


### PR DESCRIPTION
Currently the bottom of the page looks a little bit wonky, due to a small bracing error:
![image](https://user-images.githubusercontent.com/9868229/88184753-62ba5b00-cc33-11ea-9a34-8a088ac634a7.png)

This should fix it.