### PR TITLE
Make commandline parameters case insensitive

### DIFF
--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -50,8 +50,8 @@ type CliTokenReader(inputs : string[]) =
         | token ->
             let mutable prefix = null
             let mutable case = Unchecked.defaultof<_>
-            if argInfo.CliParamIndex.Value.TryGetPrefix(token, &prefix, &case) then
-                if token = prefix then CliParam(token, prefix, case, NoAssignment) |> kont
+            if argInfo.CliParamIndex.Value.TryGetCaseInsensitivePrefix(token, &prefix, &case) then
+                if token.ToLower() = prefix.ToLower() then CliParam(token, prefix, case, NoAssignment) |> kont
                 elif case.IsCustomAssignment then
                     match case.AssignmentParser.Value token with
                     | NoAssignment -> tryExtractGroupedSwitches token

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -269,12 +269,17 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
     member __.Item(key : string) =
         let mutable kr = null
         let mutable vr = Unchecked.defaultof<_>
-        if __.TryGetPrefix(key, &kr, &vr) && kr = key then vr
+        if __.TryGetCaseInsensitivePrefix(key, &kr, &vr) && kr = key then vr
         else
             raise <| new KeyNotFoundException(key)
 
+    /// Look up best matching case insensitive key entry by prefix
+    member __.TryGetCaseInsensitivePrefix(value : string, kresult : byref<string>, vresult : byref<'Value>) : bool =
+        __.TryGetPrefix(value, &kresult, &vresult) ||
+        __.TryGetPrefix(value.ToLower(), &kresult, &vresult)
+    
     /// Look up best matching key entry by prefix
-    member __.TryGetPrefix(value : string, kresult : byref<string>, vresult : byref<'Value>) : bool =
+    member private __.TryGetPrefix(value : string, kresult : byref<string>, vresult : byref<'Value>) : bool =
         // Just iterate through all the keys, picking the matching prefix
         // with the maximal length
         let mutable maxPos = -1

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -925,7 +925,7 @@ module ``Argu Tests Main Primitive`` =
     [<Fact>]
     let ``Simple command line parsing`` () =
         let args = 
-            [| "--first-parameter" ; "bar" ; "--CamelCasedArg"; "string" ; "--mandatory-arg" ; "true" ; "-D" ; 
+            [| "--first-parameter" ; "bar" ; "--camelcasedarg"; "string" ; "--mandatory-arg" ; "true" ; "-D" ; 
                 "--listener" ; "localhost" ; "8080" ; "--log-level" ; "2" |]
 
         let expected_outcome = [ First_Parameter "bar" ; CamelCasedArg "string"


### PR DESCRIPTION
Addresses https://github.com/fsprojects/Argu/issues/155 - whether or not this is strictly necessary or not is up for debate: personally I prefer `--kebab-case` parameters, though for those that use `--CamelCase` this would save adding a whole load of annotations.

Will happily amend the documentation and provide an example if this is considered a desirable change.