### PR TITLE
feat: Add GetResult(expr, defThunk)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### 6.1.3
-* Add ParseResults.GetResult(expr, defaultThunk) [#187](https://github.com/fsprojects/Argu/pull/187)
+* Add ParseResults.GetResult(expr, unit -> 'T) helper for Catch [#187](https://github.com/fsprojects/Argu/pull/187)
 
 ### 6.1.2
 * Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116) [@chestercodes](https://github.com/chestercodes) 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
+### 6.1.3
+* Add ParseResults.GetResult(expr, defaultThunk) [#187](https://github.com/fsprojects/Argu/pull/187)
+
 ### 6.1.2
-* Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116)
-* Fix Consistent handling of numeric decimal separators using invariant culture. [#159](https://github.com/fsprojects/Argu/issues/159)
+* Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116) [@chestercodes](https://github.com/chestercodes) 
+* Fix Consistent handling of numeric decimal separators using invariant culture. [#159](https://github.com/fsprojects/Argu/issues/159) [@stmax82](https://github.com/stmax82)
 
 ### 6.1.1
 * Fix CustomAssignmentOrSpacedAttribute interop with optional fields.

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -123,7 +123,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <param name="defThunk">Function used to default if no parameter has been specified.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
     member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, defThunk : unit -> 'Fields, ?source : ParseSource) : 'Fields =
-        s.TryGetResult expr)
+        s.TryGetResult(expr, ?source = source)
         |> Option.defaultWith defThunk
 
     /// <summary>Checks if parameter of specific kind has been specified.</summary>

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -100,7 +100,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
-    /// <param name="defaultValue">Return this of no parameter of specific kind has been specified.</param>
+    /// <param name="defaultValue">Return this if no parameter of specific kind has been specified.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
     member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Template>, ?defaultValue : 'Template, ?source : ParseSource) : 'Template =
         match defaultValue with
@@ -110,12 +110,21 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
-    /// <param name="defaultValue">Return this of no parameter of specific kind has been specified.</param>
+    /// <param name="defaultValue">Return this if no parameter of specific kind has been specified.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?defaultValue : 'Fields , ?source : ParseSource) : 'Fields =
+    member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?defaultValue : 'Fields, ?source : ParseSource) : 'Fields =
         match defaultValue with
         | None -> let r = getResult source expr in r.FieldContents :?> 'Fields
-        | Some def -> defaultArg (s.TryGetResult expr) def
+        | Some def -> defaultArg (s.TryGetResult(expr, ?source = source)) def
+
+    /// <summary>Returns the *last* specified parameter of given type.
+    ///          Command line parameters have precedence over AppSettings parameters.</summary>
+    /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
+    /// <param name="defThunk">Function used to default if no parameter has been specified.</param>
+    /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
+    member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, defThunk : unit -> 'Fields, ?source : ParseSource) : 'Fields =
+        s.TryGetResult expr)
+        |> Option.defaultWith defThunk
 
     /// <summary>Checks if parameter of specific kind has been specified.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -120,11 +120,15 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
-    /// <param name="defThunk">Function used to default if no parameter has been specified.</param>
+    /// <param name="defThunk">Function used to default if no parameter has been specified.
+    ///     Any resulting Exception will be trapped, and the Exception's <c>.Message</c> will be used as the Failure Message as per <c>Raise</c> and <c>Catch</c>.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member s.GetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, defThunk : unit -> 'Fields, ?source : ParseSource) : 'Fields =
-        s.TryGetResult(expr, ?source = source)
-        |> Option.defaultWith defThunk
+    /// <param name="errorCode">The error code to be returned.</param>
+    /// <param name="showUsage">Print usage together with error message.</param>
+    member s.GetResult([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, defThunk : unit -> 'Fields, ?source : ParseSource, ?errorCode, ?showUsage) : 'Fields  =
+        match s.TryGetResult(expr, ?source = source) with
+        | Some x -> x
+        | None -> s.Catch(defThunk, ?errorCode = errorCode, ?showUsage = showUsage)
 
     /// <summary>Checks if parameter of specific kind has been specified.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
@@ -139,7 +143,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <param name="msg">The error message to be displayed.</param>
     /// <param name="errorCode">The error code to be returned.</param>
     /// <param name="showUsage">Print usage together with error message.</param>
-    member _.Raise (msg : string, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
+    member _.Raise<'T>(msg : string, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
         let errorCode = defaultArg errorCode ErrorCode.PostProcess
         let showUsage = defaultArg showUsage true
         error (not showUsage) errorCode msg
@@ -148,15 +152,15 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <param name="error">The error to be displayed.</param>
     /// <param name="errorCode">The error code to be returned.</param>
     /// <param name="showUsage">Print usage together with error message.</param>
-    member r.Raise (error : exn, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
-        r.Raise (error.Message, ?errorCode = errorCode, ?showUsage = showUsage)
+    member r.Raise<'T>(error : exn, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
+        r.Raise(error.Message, ?errorCode = errorCode, ?showUsage = showUsage)
 
-    /// <summary>Handles any raised exception through the argument parser's exiter mechanism. Display usage optionally.</summary>
+    /// <summary>Handles any raised exception through the argument parser's exiter mechanism.</summary>
     /// <param name="f">The operation to be executed.</param>
     /// <param name="errorCode">The error code to be returned.</param>
-    /// <param name="showUsage">Print usage together with error message.</param>
-    member r.Catch (f : unit -> 'T, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
-        try f () with e -> r.Raise(e.Message, ?errorCode = errorCode, ?showUsage = showUsage)
+    /// <param name="showUsage">Print usage together with error message. Defaults to <c>true</c></param>
+    member r.Catch<'T>(f : unit -> 'T, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
+        try f () with e -> r.Raise(e, ?errorCode = errorCode, ?showUsage = showUsage)
 
     /// <summary>Returns the *last* specified parameter of given type.
     ///          Command line parameters have precedence over AppSettings parameters.


### PR DESCRIPTION
Useful to defer computation work (or raising of an exception in the course of that) to look up a fallback where a parameter is missing