### PR TITLE
chore: Up to warning level 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <WarningLevel>5</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -14,7 +14,7 @@ type Args =
     | Detach
 with
     interface IArgParserTemplate with
-        member __.Usage = ""
+        member _.Usage = ""
 
 (**
 

--- a/docs/perf.fsx
+++ b/docs/perf.fsx
@@ -10,7 +10,7 @@ type Arguments =
     | Argument
 with
     interface IArgParserTemplate with
-        member __.Usage =
+        member _.Usage =
             "Usage"
 
 type FactAttribute () = inherit System.Attribute()

--- a/samples/Argu.Samples.LS/Arguments.fs
+++ b/samples/Argu.Samples.LS/Arguments.fs
@@ -84,7 +84,7 @@ with
             | Ignore_Backups -> "do not list implied entries ending with ~"
             | Color _ -> "colorize the output; WHEN can be 'always' (default\nif omitted), 'auto', or 'never'"
             | Directory -> "list directories themselves, not their contents"
-            | Dired _ -> "generate output designed for Emacs' dired mode"
+            | Dired -> "generate output designed for Emacs' dired mode"
             | F -> "do not sort, enable -aU, disable -ls --color"
             | Format _ -> "append indicator (one of */=>@|) to entries"
             | Group_Directories_First -> "group directories before files;\ncan be augmented with a --sort option, but any\nuse of --sort=none (-U) disables grouping"

--- a/samples/Argu.Samples.LS/Arguments.fs
+++ b/samples/Argu.Samples.LS/Arguments.fs
@@ -72,7 +72,6 @@ type LsArguments =
     | [<AltCommandLine("-Z")>] Context
     | [<CustomCommandLine("-1")>] List_One
     | Version
-with
     interface IArgParserTemplate with
         member arg.Usage =
             match arg with

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -14,32 +14,32 @@ type ArgumentParser internal (argInfo : UnionArgInfo, _programName : string, hel
         if _usageStringCharacterWidth < 1 then invalidArg "usageStringCharacterWidth" "Must be positive value."
 
     /// Gets the help flags specified for the CLI parser
-    member __.HelpFlags = argInfo.HelpParam.Flags
+    member _.HelpFlags = argInfo.HelpParam.Flags
     /// Gets the help description specified for the CLI parser
-    member __.HelpDescription = argInfo.HelpParam.Description
+    member _.HelpDescription = argInfo.HelpParam.Description
     /// Gets the message that will be displayed at the top of the help text
-    member __.HelpTextMessage = helpTextMessage
+    member _.HelpTextMessage = helpTextMessage
     /// Returns true if parser corresponds to a subcommand
-    member __.IsSubCommandParser = argInfo.TryGetParent() |> Option.isSome
+    member _.IsSubCommandParser = argInfo.TryGetParent() |> Option.isSome
     /// If subcommand parser, gets parent argument metadata
-    member __.ParentInfo = argInfo.TryGetParent() |> Option.map (fun p -> p.ToArgumentCaseInfo())
+    member _.ParentInfo = argInfo.TryGetParent() |> Option.map (fun p -> p.ToArgumentCaseInfo())
     /// Gets the default error handler used by the instance
-    member __.ErrorHandler = errorHandler
+    member _.ErrorHandler = errorHandler
 
     /// Gets metadata for all union cases used by parser
-    member __.GetArgumentCases() =
+    member _.GetArgumentCases() =
         argInfo.Cases.Value
         |> Seq.map (fun p -> p.ToArgumentCaseInfo())
         |> Seq.toList
 
     /// Gets all subcommand parsers for given parser
-    member __.GetSubCommandParsers() =
+    member _.GetSubCommandParsers() =
         argInfo.Cases.Value
         |> Seq.choose (fun cs -> match cs.ParameterInfo.Value with SubCommand(e,nu,_) -> Some(e,nu) | _ -> None)
         |> Seq.map (fun (e,nu) ->
             e.Accept {
                 new ITemplateFunc<ArgumentParser> with
-                    member __.Invoke<'Template when 'Template :> IArgParserTemplate> () =
+                    member _.Invoke<'Template when 'Template :> IArgParserTemplate> () =
                         new ArgumentParser<'Template>(nu, _programName, helpTextMessage, _usageStringCharacterWidth, errorHandler) :> _
             })
         |> Seq.toList
@@ -49,7 +49,7 @@ type ArgumentParser internal (argInfo : UnionArgInfo, _programName : string, hel
     /// <param name="programName">Override the default program name settings.</param>
     /// <param name="hideSyntax">Do not display 'USAGE: [syntax]' at top of usage string. Defaults to false.</param>
     /// <param name="usageStringCharacterWidth">Text width used when formatting the usage string.</param>
-    member __.PrintUsage (?message : string, ?programName : string, ?hideSyntax : bool, ?usageStringCharacterWidth : int) : string =
+    member _.PrintUsage (?message : string, ?programName : string, ?hideSyntax : bool, ?usageStringCharacterWidth : int) : string =
         let programName = defaultArg programName _programName
         let hideSyntax = defaultArg hideSyntax false
         let usageStringCharacterWidth = defaultArg usageStringCharacterWidth _usageStringCharacterWidth
@@ -60,7 +60,7 @@ type ArgumentParser internal (argInfo : UnionArgInfo, _programName : string, hel
     /// </summary>
     /// <param name="programName">Program name identifier placed at start of syntax string</param>
     /// <param name="usageStringCharacterWidth">Text width used when formatting the usage string.</param>
-    member __.PrintCommandLineSyntax (?programName : string, ?usageStringCharacterWidth : int) : string =
+    member _.PrintCommandLineSyntax (?programName : string, ?usageStringCharacterWidth : int) : string =
         let programName = defaultArg programName _programName
         let usageStringCharacterWidth = defaultArg usageStringCharacterWidth _usageStringCharacterWidth
         mkCommandLineSyntax argInfo "" usageStringCharacterWidth programName |> StringExpr.build
@@ -107,7 +107,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     new (?programName : string, ?helpTextMessage : string, ?usageStringCharacterWidth : int, ?errorHandler : IExiter, ?checkStructure: bool) =
         let usageStringCharacterWidth = match usageStringCharacterWidth with None -> getDefaultCharacterWidth() | Some w -> w
         let programName = match programName with Some pn -> pn | None -> currentProgramName.Value
-        let errorHandler = match errorHandler with Some e -> e  | None -> new ExceptionExiter() :> _
+        let errorHandler = match errorHandler with Some e -> e  | None -> ExceptionExiter() :> _
 
         let argInfo =
             match checkStructure with
@@ -124,7 +124,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     /// <param name="ignoreMissing">Ignore errors caused by the Mandatory attribute. Defaults to false.</param>
     /// <param name="ignoreUnrecognized">Ignore CLI arguments that do not match the schema. Defaults to false.</param>
     /// <param name="raiseOnUsage">Treat '--help' parameters as parse errors. Defaults to true.</param>
-    member __.ParseCommandLine (?inputs : string [], ?ignoreMissing, ?ignoreUnrecognized, ?raiseOnUsage) : ParseResults<'Template> =
+    member _.ParseCommandLine (?inputs : string [], ?ignoreMissing, ?ignoreUnrecognized, ?raiseOnUsage) : ParseResults<'Template> =
         let ignoreMissing = defaultArg ignoreMissing false
         let ignoreUnrecognized = defaultArg ignoreUnrecognized false
         let raiseOnUsage = defaultArg raiseOnUsage true
@@ -142,7 +142,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     /// <summary>Parse arguments using specified configuration reader only. This defaults to the AppSettings configuration of the current process.</summary>
     /// <param name="configurationReader">Configuration reader used to source the arguments. Defaults to the AppSettings configuration of the current process.</param>
     /// <param name="ignoreMissing">Ignore errors caused by the Mandatory attribute. Defaults to false.</param>
-    member __.ParseConfiguration (configurationReader : IConfigurationReader, ?ignoreMissing : bool) : ParseResults<'Template> =
+    member _.ParseConfiguration (configurationReader : IConfigurationReader, ?ignoreMissing : bool) : ParseResults<'Template> =
         let ignoreMissing = defaultArg ignoreMissing false
 
         try
@@ -160,7 +160,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     /// <param name="ignoreMissing">Ignore errors caused by the Mandatory attribute. Defaults to false.</param>
     /// <param name="ignoreUnrecognized">Ignore CLI arguments that do not match the schema. Defaults to false.</param>
     /// <param name="raiseOnUsage">Treat '--help' parameters as parse errors. Defaults to true.</param>
-    member __.Parse (?inputs : string [], ?configurationReader : IConfigurationReader, ?ignoreMissing, ?ignoreUnrecognized, ?raiseOnUsage) : ParseResults<'Template> =
+    member _.Parse (?inputs : string [], ?configurationReader : IConfigurationReader, ?ignoreMissing, ?ignoreUnrecognized, ?raiseOnUsage) : ParseResults<'Template> =
         let ignoreMissing = defaultArg ignoreMissing false
         let ignoreUnrecognized = defaultArg ignoreUnrecognized false
         let raiseOnUsage = defaultArg raiseOnUsage true
@@ -183,16 +183,16 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     ///     Converts a sequence of template argument inputs into a ParseResults instance
     /// </summary>
     /// <param name="inputs">Argument input sequence.</param>
-    member __.ToParseResults (inputs : seq<'Template>) : ParseResults<'Template> =
+    member _.ToParseResults (inputs : seq<'Template>) : ParseResults<'Template> =
         mkParseResultFromValues argInfo errorHandler _usageStringCharacterWidth _programName helpTextMessage inputs
 
     /// <summary>
     ///     Gets a subparser associated with specific subcommand instance
     /// </summary>
     /// <param name="expr">Expression providing the subcommand union constructor.</param>
-    member __.GetSubCommandParser ([<ReflectedDefinition>] expr : Expr<ParseResults<'SubTemplate> -> 'Template>) : ArgumentParser<'SubTemplate> =
+    member _.GetSubCommandParser ([<ReflectedDefinition>] expr : Expr<ParseResults<'SubTemplate> -> 'Template>) : ArgumentParser<'SubTemplate> =
         let uci = expr2Uci expr
-        let case = argInfo.Cases.Value.[uci.Tag]
+        let case = argInfo.Cases.Value[uci.Tag]
         match case.ParameterInfo.Value with
         | SubCommand (_,nestedUnion,_) ->
             new ArgumentParser<'SubTemplate>(nestedUnion, _programName, helpTextMessage, _usageStringCharacterWidth, errorHandler)
@@ -202,40 +202,40 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     ///     Gets the F# union tag representation for given argument
     /// </summary>
     /// <param name="value">Argument instance.</param>
-    member __.GetTag(value : 'Template) : int =
+    member _.GetTag(value : 'Template) : int =
         argInfo.TagReader.Value (value :> obj)
 
     /// <summary>
     ///     Gets argument metadata for given argument instance.
     /// </summary>
     /// <param name="value">Argument instance.</param>
-    member __.GetArgumentCaseInfo(value : 'Template) : ArgumentCaseInfo =
+    member _.GetArgumentCaseInfo(value : 'Template) : ArgumentCaseInfo =
         let tag = argInfo.TagReader.Value (value :> obj)
-        argInfo.Cases.Value.[tag].ToArgumentCaseInfo()
+        argInfo.Cases.Value[tag].ToArgumentCaseInfo()
 
     /// <summary>
     ///     Gets argument metadata for given union case constructor
     /// </summary>
     /// <param name="ctorExpr">Quoted union case constructor.</param>
-    member __.GetArgumentCaseInfo([<ReflectedDefinition>] ctorExpr : Expr<'Fields -> 'Template>) : ArgumentCaseInfo =
+    member _.GetArgumentCaseInfo([<ReflectedDefinition>] ctorExpr : Expr<'Fields -> 'Template>) : ArgumentCaseInfo =
         let uci = expr2Uci ctorExpr
-        argInfo.Cases.Value.[uci.Tag].ToArgumentCaseInfo()
+        argInfo.Cases.Value[uci.Tag].ToArgumentCaseInfo()
 
     /// <summary>Prints parameters in command line format. Useful for argument string generation.</summary>
-    member __.PrintCommandLineArguments (args : 'Template list) : string [] =
+    member _.PrintCommandLineArguments (args : 'Template list) : string [] =
         mkCommandLineArgs argInfo (Seq.cast args) |> Seq.toArray
 
     /// <summary>Prints parameters in command line format. Useful for argument string generation.</summary>
-    member __.PrintCommandLineArgumentsFlat (args : 'Template list) : string =
-        __.PrintCommandLineArguments args |> flattenCliTokens
+    member ap.PrintCommandLineArgumentsFlat (args : 'Template list) : string =
+        ap.PrintCommandLineArguments args |> flattenCliTokens
 
     /// <summary>Prints parameters in App.Config format.</summary>
     /// <param name="args">The parameters that fill out the XML document.</param>
     /// <param name="printComments">Print XML comments over every configuration entry.</param>
-    member __.PrintAppSettingsArguments (args : 'Template list, ?printComments : bool) : string =
+    member _.PrintAppSettingsArguments (args : 'Template list, ?printComments : bool) : string =
         let printComments = defaultArg printComments true
         let xmlDoc = mkAppSettingsDocument argInfo printComments args
-        use writer = { new System.IO.StringWriter() with member __.Encoding = System.Text.Encoding.UTF8 }
+        use writer = { new System.IO.StringWriter() with member _.Encoding = System.Text.Encoding.UTF8 }
         xmlDoc.Save writer
         writer.Flush()
         writer.ToString()

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -35,7 +35,7 @@ type ExactlyOnceAttribute () = inherit Attribute ()
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type InheritAttribute() = inherit Attribute()
 
-/// Denotes that the given argument should accummulate any unrecognized arguments it encounters.
+/// Denotes that the given argument should accumulate any unrecognized arguments it encounters.
 /// Must contain a single field of type string
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type GatherUnrecognizedAttribute() = inherit Attribute()
@@ -61,7 +61,7 @@ type NoAppSettingsAttribute () = inherit Attribute ()
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
 type HelpFlagsAttribute ([<ParamArray>] names : string []) = 
     inherit Attribute()
-    member __.Names = names
+    member _.Names = names
 
 /// Specifies that Help/Usage switches should be disabled for the CLI.
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
@@ -71,13 +71,13 @@ type DisableHelpFlagsAttribute () = inherit HelpFlagsAttribute ()
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
 type HelpDescriptionAttribute (description : string) =
     inherit Attribute()
-    member __.Description = description
+    member _.Description = description
 
 /// Declares that argument should be placed at specific position.
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CliPositionAttribute(position : CliPosition) =
     inherit Attribute()
-    member __.Position = position
+    member _.Position = position
 
 /// Declares that argument can only be placed at the beginning of the CLI syntax.
 /// A parse exception will be raised if that is not the case.
@@ -101,8 +101,8 @@ type SubCommandAttribute () = inherit Attribute()
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type MainCommandAttribute (argumentName : string) = 
     inherit Attribute()
-    new () = new MainCommandAttribute(null)
-    member __.ArgumentName = argumentName
+    new () = MainCommandAttribute(null)
+    member _.ArgumentName = argumentName
 
 /// Print F# 3.1 field labels in usage string. OBSOLETE
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
@@ -116,7 +116,7 @@ type PrintLabelsAttribute () = inherit Attribute ()
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAssignmentAttribute (separator : string) = 
     inherit Attribute ()
-    member __.Separator = separator
+    member _.Separator = separator
 
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
@@ -138,7 +138,7 @@ type ColonAssignmentAttribute () =
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAssignmentOrSpacedAttribute (separator : string) =
     inherit Attribute ()
-    member __.Separator = separator
+    member _.Separator = separator
 
 /// Use '--param=arg' assignment syntax in CLI.
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
@@ -159,8 +159,8 @@ type ColonAssignmentOrSpacedAttribute () =
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string []) =
     inherit Attribute ()
-    member __.Name = name
-    member __.AltNames = altNames
+    member _.Name = name
+    member _.AltNames = altNames
 
 /// Declares a set of secondary CLI identifiers for the current parameter.
 /// Does not replace the default identifier which is either auto-generated
@@ -168,27 +168,27 @@ type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string 
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
 type AltCommandLineAttribute ([<ParamArray>] names : string []) = 
     inherit Attribute ()
-    member __.Names = names
+    member _.Names = names
 
 /// Declares a custom key identifier for the current parameter in AppSettings parsing.
 /// Replaces the auto-generated identifier name.
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAppSettingsAttribute (name : string) =
     inherit Attribute ()
-    member __.Name = name
+    member _.Name = name
 
 /// Specify a custom value separator in AppSettings parsing parameters.
 /// Used in CSV or list-based parameter parsing.
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
 type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], splitOptions : StringSplitOptions) =
     inherit Attribute()
-    new (separator : char) = new AppSettingsSeparatorAttribute([|string separator|], StringSplitOptions.None)
-    member __.Separators = separators
-    member __.SplitOptions = splitOptions
+    new (separator : char) = AppSettingsSeparatorAttribute([|string separator|], StringSplitOptions.None)
+    member _.Separators = separators
+    member _.SplitOptions = splitOptions
 
 /// Specifies a custom prefix for auto-generated CLI names.
 /// This defaults to double dash ('--').
 [<AttributeUsage(AttributeTargets.Property ||| AttributeTargets.Class, AllowMultiple = false)>]
 type CliPrefixAttribute(prefix : string) = 
     inherit Attribute() 
-    member __.Prefix = prefix
+    member _.Prefix = prefix

--- a/src/Argu/ConfigReaders.fs
+++ b/src/Argu/ConfigReaders.fs
@@ -41,8 +41,8 @@ type EnvironmentVariableConfigurationReader() =
 type DictionaryConfigurationReader (keyValueDictionary : IDictionary<string, string>, ?name : string) =
     let name = defaultArg name "Dictionary configuration reader."
     interface IConfigurationReader with
-        member __.Name = name
-        member __.GetValue(key:string) =
+        member _.Name = name
+        member _.GetValue(key:string) =
             let ok,value = keyValueDictionary.TryGetValue key
             if ok then value else null
 
@@ -50,8 +50,8 @@ type DictionaryConfigurationReader (keyValueDictionary : IDictionary<string, str
 type FunctionConfigurationReader (configFunc : string -> string option, ?name : string) =
     let name = defaultArg name "Function configuration reader."
     interface IConfigurationReader with
-        member __.Name = name
-        member __.GetValue(key:string) =
+        member _.Name = name
+        member _.GetValue(key:string) =
             match configFunc key with
             | None -> null
             | Some v -> v
@@ -59,46 +59,46 @@ type FunctionConfigurationReader (configFunc : string -> string option, ?name : 
 /// AppSettings XML configuration reader
 type AppSettingsConfigurationReader () =
     interface IConfigurationReader with
-        member __.Name = "AppSettings configuration reader"
-        member __.GetValue(key:string) = ConfigurationManager.AppSettings.[key]
+        member _.Name = "AppSettings configuration reader"
+        member _.GetValue(key:string) = ConfigurationManager.AppSettings[key]
 
 /// AppSettings XML configuration reader
 type AppSettingsConfigurationFileReader private (xmlPath : string, kv : KeyValueConfigurationCollection) =
-    member __.Path = xmlPath
+    member _.Path = xmlPath
     interface IConfigurationReader with
-        member __.Name = sprintf "App.config configuration reader: %s" xmlPath
-        member __.GetValue(key:string) =
-            match kv.[key] with
+        member _.Name = sprintf "App.config configuration reader: %s" xmlPath
+        member _.GetValue(key:string) =
+            match kv[key] with
             | null -> null
             | entry -> entry.Value
 
     /// Create used supplied XML file path
     static member Create(path : string) =
-        if not <| File.Exists path then raise <| new FileNotFoundException(path)
-        let fileMap = new ExeConfigurationFileMap()
+        if not <| File.Exists path then raise <| FileNotFoundException(path)
+        let fileMap = ExeConfigurationFileMap()
         fileMap.ExeConfigFilename <- path
         let config = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None)
-        new AppSettingsConfigurationFileReader(path, config.AppSettings.Settings)
+        AppSettingsConfigurationFileReader(path, config.AppSettings.Settings)
 
 /// Configuration reader implementations
 type ConfigurationReader =
     /// Create a configuration reader that always returns null
-    static member NullReader = new NullConfigurationReader() :> IConfigurationReader
+    static member NullReader = NullConfigurationReader() :> IConfigurationReader
 
     /// Create a configuration reader instance using an IDictionary instance
     static member FromDictionary(keyValueDictionary : IDictionary<string,string>, ?name : string) =
-        new DictionaryConfigurationReader(keyValueDictionary, ?name = name) :> IConfigurationReader
+        DictionaryConfigurationReader(keyValueDictionary, ?name = name) :> IConfigurationReader
 
     /// Create a configuration reader instance using an F# function
     static member FromFunction(reader : string -> string option, ?name : string) =
-        new FunctionConfigurationReader(reader, ?name = name) :> IConfigurationReader
+        FunctionConfigurationReader(reader, ?name = name) :> IConfigurationReader
 
     /// Create a configuration reader instance using environment variables
     static member FromEnvironmentVariables() =
-        new EnvironmentVariableConfigurationReader() :> IConfigurationReader
+        EnvironmentVariableConfigurationReader() :> IConfigurationReader
 
     /// Create a configuration reader instance using the application's resident AppSettings configuration
-    static member FromAppSettings() = new AppSettingsConfigurationReader() :> IConfigurationReader
+    static member FromAppSettings() = AppSettingsConfigurationReader() :> IConfigurationReader
     /// Create a configuration reader instance using a local xml App.Config file
     static member FromAppSettingsFile(path : string) = AppSettingsConfigurationFileReader.Create(path) :> IConfigurationReader
     /// Create a configuration reader instance using the location of an assembly file

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -21,15 +21,15 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         let flags = defaultArg flags ParseSource.All
         fun x -> Enum.hasFlag flags x.Source
 
-    let getResults rs (e : Expr) = results.Cases.[expr2Uci(e).Tag] |> Seq.filter (restrictF rs)
+    let getResults rs (e : Expr) = results.Cases[expr2Uci(e).Tag] |> Seq.filter (restrictF rs)
     let containsResult rs (e : Expr) = e |> getResults rs |> Seq.isEmpty |> not
     let tryGetResult rs (e : Expr) = e |> getResults rs |> Seq.tryLast
     let getResult rs (e : Expr) =
         let id = expr2Uci e
-        let results = results.Cases.[id.Tag]
+        let results = results.Cases[id.Tag]
         match Array.tryLast results with
         | None ->
-            let aI = argInfo.Cases.Value.[id.Tag]
+            let aI = argInfo.Cases.Value[id.Tag]
             errorf (not aI.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." aI.Name.Value
         | Some r when restrictF rs r -> r
         | Some r -> errorf (not r.CaseInfo.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." r.CaseInfo.Name.Value
@@ -49,52 +49,52 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     interface IParseResult with
         member __.GetAllResults () = __.GetAllResults() |> Seq.map box
 
-    member __.ErrorHandler = exiter
-    member internal __.ProgramName = programName
-    member internal __.Description = description
-    member internal __.ArgInfo = argInfo
-    member internal __.CharacterWidth = usageStringCharWidth
+    member _.ErrorHandler = exiter
+    member internal _.ProgramName = programName
+    member internal _.Description = description
+    member internal _.ArgInfo = argInfo
+    member internal _.CharacterWidth = usageStringCharWidth
 
     /// Returns true if '--help' parameter has been specified in the command line.
-    member __.IsUsageRequested = results.IsUsageRequested
+    member _.IsUsageRequested = results.IsUsageRequested
 
     /// Gets all unrecognized CLI parameters which
     /// accumulates if parsed with 'ignoreUnrecognized = true'
-    member __.UnrecognizedCliParams = results.UnrecognizedCliParams
+    member _.UnrecognizedCliParams = results.UnrecognizedCliParams
 
     /// Gets all parse results that are not part of the current parsing context
     /// This is only applicable to subcommand parsing operations
-    member __.UnrecognizedCliParseResults = results.UnrecognizedCliParseResults
+    member _.UnrecognizedCliParseResults = results.UnrecognizedCliParseResults
 
     /// <summary>Query parse results for parameterless argument.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template list =
+    member _.GetResults ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template list =
         expr |> getResults source |> Seq.map (fun r -> r.Value :?> 'Template) |> Seq.toList
 
     /// <summary>Query parse results for argument with parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetResults ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields list =
+    member _.GetResults ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields list =
         expr |> getResults source |> Seq.map (fun r -> r.FieldContents :?> 'Fields) |> Seq.toList
 
     /// <summary>Gets all parse results.</summary>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.GetAllResults (?source : ParseSource) : 'Template list =
+    member _.GetAllResults (?source : ParseSource) : 'Template list =
         getAllResults source
 
     /// <summary>Returns the *last* specified parameter of given type, if it exists.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template option =
+    member _.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : 'Template option =
         expr |> tryGetResult source |> Option.map (fun r -> r.Value :?> 'Template)
 
     /// <summary>Returns the *last* specified parameter of given type, if it exists.
     ///          Command line parameters have precedence over AppSettings parameters.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields option =
+    member _.TryGetResult ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : 'Fields option =
         expr |> tryGetResult source |> Option.map (fun r -> r.FieldContents :?> 'Fields)
 
     /// <summary>Returns the *last* specified parameter of given type.
@@ -120,17 +120,17 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     /// <summary>Checks if parameter of specific kind has been specified.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.Contains ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : bool = containsResult source expr
+    member _.Contains ([<ReflectedDefinition>] expr : Expr<'Template>, ?source : ParseSource) : bool = containsResult source expr
     /// <summary>Checks if parameter of specific kind has been specified.</summary>
     /// <param name="expr">The name of the parameter, expressed as quotation of DU constructor.</param>
     /// <param name="source">Optional source restriction: AppSettings or CommandLine.</param>
-    member __.Contains ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : bool = containsResult source expr
+    member _.Contains ([<ReflectedDefinition>] expr : Expr<'Fields -> 'Template>, ?source : ParseSource) : bool = containsResult source expr
 
     /// <summary>Raise an error through the argument parser's exiter mechanism. Display usage optionally.</summary>
     /// <param name="msg">The error message to be displayed.</param>
     /// <param name="errorCode">The error code to be returned.</param>
     /// <param name="showUsage">Print usage together with error message.</param>
-    member __.Raise (msg : string, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
+    member _.Raise (msg : string, ?errorCode : ErrorCode, ?showUsage : bool) : 'T =
         let errorCode = defaultArg errorCode ErrorCode.PostProcess
         let showUsage = defaultArg showUsage true
         error (not showUsage) errorCode msg

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -47,7 +47,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         |> Seq.toList
 
     interface IParseResult with
-        member __.GetAllResults () = __.GetAllResults() |> Seq.map box
+        member x.GetAllResults () = x.GetAllResults() |> Seq.map box
 
     member _.ErrorHandler = exiter
     member internal _.ProgramName = programName

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -110,10 +110,10 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
 
         agg.Add result
 
-    member __.AppendResult caseInfo context arguments =
+    member x.AppendResult caseInfo context arguments =
         let result = mkUnionCase caseInfo resultCount ParseSource.CommandLine context arguments
         if result.CaseInfo.Depth = argInfo.Depth then
-            __.AppendResultInner(result)
+            x.AppendResultInner(result)
         else
             // this parse result corresponds to an inherited parameter
             // from a parent syntax. Use the ResultAggregator stack to
@@ -123,11 +123,11 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
 
     member _.AppendUnrecognized(token:string) = unrecognized.Add token
 
-    member __.ToUnionParseResults() =
+    member x.ToUnionParseResults() =
         { Cases = results.Value |> Array.map (fun c -> c.ToArray()) ;
           UnrecognizedCliParams = Seq.toList unrecognized ;
           UnrecognizedCliParseResults = Seq.toList unrecognizedParseResults ;
-          IsUsageRequested = __.IsUsageRequested }
+          IsUsageRequested = x.IsUsageRequested }
 
 // this rudimentary stack implementation assumes that only one subcommand
 // can occur within any particular context; no need implement popping etc.

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -15,15 +15,15 @@ type CliTokenReader(inputs : string[]) =
     let mutable isPeekedValue = false
     let mutable peekedValue = Unchecked.defaultof<CliParseToken>
 
-    member __.BeginCliSegment() =
+    member _.BeginCliSegment() =
         segmentStartPos <- position
 
     /// returns the substring that corresponds to the current argument being parsed
     /// e.g "-port 2" from "-Cf -port 2 -bar"
-    member __.CurrentSegment =
-        inputs.[segmentStartPos .. position - 1] |> flattenCliTokens
+    member _.CurrentSegment =
+        inputs[segmentStartPos .. position - 1] |> flattenCliTokens
 
-    member __.GetNextToken (peekOnly : bool) (argInfo : UnionArgInfo) =
+    member _.GetNextToken (peekOnly : bool) (argInfo : UnionArgInfo) =
         // continuation which decides how to consume parsed token
         let inline kont result =
             if peekOnly then
@@ -44,7 +44,7 @@ type CliTokenReader(inputs : string[]) =
         if isPeekedValue then kont peekedValue
         elif position = inputs.Length then kont EndOfStream else
 
-        let token = inputs.[position]
+        let token = inputs[position]
 
         match token with
         | token when argInfo.HelpParam.IsHelpFlag token -> HelpArgument token |> kont
@@ -63,30 +63,30 @@ type CliTokenReader(inputs : string[]) =
             else
                 tryExtractGroupedSwitches token |> kont
 
-    member __.MoveNext() =
+    member _.MoveNext() =
         if position < inputs.Length then
             position <- position + 1
             isPeekedValue <- false
             peekedValue <- Unchecked.defaultof<_>
 
-    member __.IsCompleted = position = inputs.Length
+    member _.IsCompleted = position = inputs.Length
 
 type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParseResultAggregatorStack) =
     let mutable resultCount = 0
     let mutable isSubCommandDefined = false
     let mutable isMainCommandDefined = false
     let mutable lastResult : UnionCaseParseResult option = None
-    let unrecognized = new ResizeArray<string>()
-    let unrecognizedParseResults = new ResizeArray<obj>()
-    let results = lazy(argInfo.Cases.Value |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult> ()))
+    let unrecognized = ResizeArray<string>()
+    let unrecognizedParseResults = ResizeArray<obj>()
+    let results = lazy(argInfo.Cases.Value |> Array.map (fun _ -> ResizeArray<UnionCaseParseResult>()))
 
     member val IsUsageRequested = false with get,set
 
-    member __.ResultCount = resultCount
-    member __.IsSubCommandDefined = isSubCommandDefined
-    member __.IsMainCommandDefined = isMainCommandDefined
+    member _.ResultCount = resultCount
+    member _.IsSubCommandDefined = isSubCommandDefined
+    member _.IsMainCommandDefined = isMainCommandDefined
 
-    member __.AppendResultInner(result : UnionCaseParseResult) =
+    member _.AppendResultInner(result : UnionCaseParseResult) =
         if result.CaseInfo.IsFirst && resultCount > 0 then
             error argInfo ErrorCode.CommandLine "argument '%s' should precede all other arguments." result.ParseContext
 
@@ -99,7 +99,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
         if result.CaseInfo.IsMainCommand then isMainCommandDefined <- true
 
         resultCount <- resultCount + 1
-        let agg = results.Value.[result.Tag]
+        let agg = results.Value[result.Tag]
         if result.CaseInfo.IsUnique.Value && agg.Count > 0 then
             error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name.Value
 
@@ -121,7 +121,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
             if stack.TryDispatchResult result then ()
             else unrecognizedParseResults.Add result.Value
 
-    member __.AppendUnrecognized(token:string) = unrecognized.Add token
+    member _.AppendUnrecognized(token:string) = unrecognized.Add token
 
     member __.ToUnionParseResults() =
         { Cases = results.Value |> Array.map (fun c -> c.ToArray()) ;
@@ -131,20 +131,20 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
 
 // this rudimentary stack implementation assumes that only one subcommand
 // can occur within any particular context; no need implement popping etc.
-// Note that inheritting subcommands is explicitly prohibited by the library.
+// Note that inheriting subcommands is explicitly prohibited by the library.
 and CliParseResultAggregatorStack (context : UnionArgInfo) =
     let offset = context.Depth
-    let stack = new ResizeArray<CliParseResultAggregator>(capacity = 2)
+    let stack = ResizeArray<CliParseResultAggregator>(capacity = 2)
 
-    member __.TryDispatchResult(result : UnionCaseParseResult) =
+    member _.TryDispatchResult(result : UnionCaseParseResult) =
         if result.CaseInfo.Depth < offset then false
         else
-            stack.[result.CaseInfo.Depth - offset].AppendResultInner result
+            stack[result.CaseInfo.Depth - offset].AppendResultInner result
             true
 
     member self.CreateNextAggregator(argInfo : UnionArgInfo) =
         assert(stack.Count = argInfo.Depth - offset)
-        let agg = new CliParseResultAggregator(argInfo, self)
+        let agg = CliParseResultAggregator(argInfo, self)
         stack.Add agg
         agg
 
@@ -187,8 +187,8 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                 // we need a way to backtrack in case of a parse error.
                 // In that case, we pass any accumulated tokens to the regular
                 // unrecognized argument resolution logic
-                let tokens = new ResizeArray<string>(5)
-                let fields = new ResizeArray<obj>(5)
+                let tokens = ResizeArray<string>(5)
+                let fields = ResizeArray<obj>(5)
                 let handleUnrecognized =
                     state.IgnoreUnrecognizedArgs ||
                     Option.isSome argInfo.UnrecognizedGatherParam.Value
@@ -197,7 +197,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                     tokens.Clear(); fields.Clear()
                     let rec aux i =
                         if i = parsers.Length then () else
-                        let p = parsers.[i]
+                        let p = parsers[i]
                         let isFirst = isFirst && i = 0
                         let nextToken =
                             if isFirst then UnrecognizedOrArgument token
@@ -250,7 +250,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
             | ListParam(existential, field) ->
                 ignore <| existential.Accept { new IFunc<bool> with
-                    member __.Invoke<'T>() =
+                    member _.Invoke<'T>() =
                         let rec gather isFirst args =
                             let nextToken =
                                 if isFirst then UnrecognizedOrArgument token
@@ -294,7 +294,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
     | GroupedParams(_, switches) ->
         for sw in switches do
-            let caseInfo = argInfo.CliParamIndex.Value.[sw]
+            let caseInfo = argInfo.CliParamIndex.Value[sw]
             match caseInfo.ParameterInfo.Value with
             | Primitives [||] -> aggregator.AppendResult caseInfo sw [||]
             | OptionalParam _ -> aggregator.AppendResult caseInfo sw [|None|]
@@ -373,7 +373,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
         | OptionalParam(existential, field) when caseInfo.IsCustomAssignment ->
             let optArgument = existential.Accept { new IFunc<obj> with
-                member __.Invoke<'T> () =
+                member _.Invoke<'T> () =
                     match assignment with
                     | NoAssignment ->
                         parseOptionalWithoutAssignment<'T> field state argInfo
@@ -390,14 +390,14 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
         | OptionalParam(existential, field) ->
             let optArgument = existential.Accept { new IFunc<obj> with
-                member __.Invoke<'T> () =
+                member _.Invoke<'T> () =
                     parseOptionalWithoutAssignment<'T> field state argInfo }
 
             aggregator.AppendResult caseInfo name [| optArgument |]
 
         | ListParam(existential, field) ->
             let listArg = existential.Accept { new IFunc<obj> with
-                member __.Invoke<'T>() =
+                member _.Invoke<'T>() =
                     let args = new ResizeArray<'T> ()
                     let rec gather () =
                         match state.Reader.GetNextToken true argInfo with
@@ -420,7 +420,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
             let nestedResults = parseCommandLineInner state nestedUnion
             let result =
                 existential.Accept { new ITemplateFunc<obj> with
-                    member __.Invoke<'Template when 'Template :> IArgParserTemplate> () =
+                    member _.Invoke<'Template when 'Template :> IArgParserTemplate> () =
                         new ParseResults<'Template>(nestedUnion, nestedResults, state.ProgramName, state.Description, state.UsageStringCharWidth, state.Exiter) :> obj }
 
             aggregator.AppendResult caseInfo name [|result|]
@@ -441,9 +441,9 @@ and private parseCommandLineInner (state : CliParseState) (argInfo : UnionArgInf
 and parseCommandLine (argInfo : UnionArgInfo) (programName : string) (description : string option) (width : int) (exiter : IExiter)
                         (raiseOnUsage : bool) (ignoreUnrecognized : bool) (inputs : string []) =
     let state = {
-        Reader = new CliTokenReader(inputs)
+        Reader = CliTokenReader(inputs)
         ProgramName = programName
-        ResultStack = new CliParseResultAggregatorStack(argInfo)
+        ResultStack = CliParseResultAggregatorStack(argInfo)
         Description = description
         UsageStringCharWidth = width
         RaiseOnUsage = raiseOnUsage

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module internal Argu.CliParser
 
+[<NoComparison; NoEquality>]
 type CliParseToken =
     | EndOfStream
     | CliParam of token:string * switch:string * caseInfo:UnionCaseArgInfo * assignment:Assignment
@@ -147,7 +148,7 @@ and CliParseResultAggregatorStack (context : UnionArgInfo) =
         stack.Add agg
         agg
 
-
+[<NoComparison; NoEquality>]
 type CliParseState =
     {
         ProgramName : string

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -3,7 +3,9 @@ module internal Argu.CommonParsers
 
 type KeyValueParseResult = Choice<UnionCaseParseResult [], exn>
 
+[<NoComparison; NoEquality>]
 exception ParseError of message:string * code:ErrorCode * argInfo:UnionArgInfo
+[<NoComparison; NoEquality>]
 exception HelpText of subcommand:UnionArgInfo
 
 let inline error argInfo code fmt =

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -26,15 +26,15 @@ let mkParseResultFromValues (info : UnionArgInfo) (exiter : IExiter) (width : in
                             (programName : string) (description : string option)
                             (values : seq<'Template>) =
 
-    let agg = info.Cases.Value |> Array.map (fun _ -> new ResizeArray<UnionCaseParseResult>())
+    let agg = info.Cases.Value |> Array.map (fun _ -> ResizeArray<UnionCaseParseResult>())
     let mutable i = 0
     for value in values do
         let value = value :> obj
         let tag = info.TagReader.Value value
-        let case = info.Cases.Value.[tag]
+        let case = info.Cases.Value[tag]
         let fields = case.FieldReader.Value value
         let result = mkUnionCase case i ParseSource.None case.Name.Value fields
-        agg.[tag].Add result
+        agg[tag].Add result
         i <- i + 1
 
     let results =
@@ -57,8 +57,8 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
 
     let emptyResult = Choice1Of2 [||]
     let combineSingle (caseInfo : UnionCaseArgInfo) =
-        let acr = match appSettingsResults with None -> emptyResult | Some ar -> ar.[caseInfo.Tag]
-        let clr = match commandLineResults with None -> [||] | Some cl -> cl.Cases.[caseInfo.Tag]
+        let acr = match appSettingsResults with None -> emptyResult | Some ar -> ar[caseInfo.Tag]
+        let clr = match commandLineResults with None -> [||] | Some cl -> cl.Cases[caseInfo.Tag]
 
         let combined =
             match acr, clr with

--- a/src/Argu/Parsers/KeyValue.fs
+++ b/src/Argu/Parsers/KeyValue.fs
@@ -17,6 +17,7 @@ type KeyValueParseResults (argInfo : UnionArgInfo) =
 
     member __.Results : KeyValueParseResult [] = results
 
+[<NoComparison; NoEquality>]
 type KeyValueParseState =
     {
         ArgInfo : UnionArgInfo

--- a/src/Argu/Parsers/KeyValue.fs
+++ b/src/Argu/Parsers/KeyValue.fs
@@ -9,13 +9,13 @@ type KeyValueParseResult = Choice<UnionCaseParseResult [], exn>
 type KeyValueParseResults (argInfo : UnionArgInfo) =
     let emptyResult = Choice1Of2 [||]
     let results = Array.init argInfo.Cases.Value.Length (fun _ -> emptyResult)
-    member __.AddResults (case : UnionCaseArgInfo) (ts : UnionCaseParseResult []) =
-        results.[case.Tag] <- Choice1Of2 ts
+    member _.AddResults (case : UnionCaseArgInfo) (ts : UnionCaseParseResult []) =
+        results[case.Tag] <- Choice1Of2 ts
 
-    member __.AddException (case : UnionCaseArgInfo) exn =
-        results.[case.Tag] <- Choice2Of2 exn
+    member _.AddException (case : UnionCaseArgInfo) exn =
+        results[case.Tag] <- Choice2Of2 exn
 
-    member __.Results : KeyValueParseResult [] = results
+    member _.Results : KeyValueParseResult [] = results
 
 [<NoComparison; NoEquality>]
 type KeyValueParseState =
@@ -57,7 +57,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
                     let parseNext (parser : FieldParserInfo) =
                         if !pos < tokens.Length then
                             try
-                                let tok = tokens.[!pos]
+                                let tok = tokens[!pos]
                                 incr pos
                                 parser.Parser tok
 
@@ -105,6 +105,6 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
 ///     Parse a given key/value configuration
 /// </summary>
 let parseKeyValueConfig (configReader : IConfigurationReader) (argInfo : UnionArgInfo) =
-    let state = { ArgInfo = argInfo ; Reader = configReader ; Results = new KeyValueParseResults(argInfo) }
+    let state = { ArgInfo = argInfo ; Reader = configReader ; Results = KeyValueParseResults(argInfo) }
     for caseInfo in argInfo.Cases.Value do parseKeyValuePartial state caseInfo
     state.Results.Results

--- a/src/Argu/Parsers/KeyValue.fs
+++ b/src/Argu/Parsers/KeyValue.fs
@@ -77,7 +77,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
 
                 | OptionalParam (existential, fp) ->
                     let parsed = existential.Accept { new IFunc<obj> with
-                        member __.Invoke<'T>() =
+                        member _.Invoke<'T>() =
                             try fp.Parser entry :?> 'T |> Some :> obj
                             with _ -> error state.ArgInfo ErrorCode.AppSettings "AppSettings entry '%s' is not <%s>." name fp.Description }
 
@@ -87,7 +87,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
                 | ListParam (existential, fp) ->
                     let tokens = entry.Split(caseInfo.AppSettingsSeparators, caseInfo.AppSettingsSplitOptions)
                     let results = existential.Accept { new IFunc<obj> with
-                        member __.Invoke<'T>() =
+                        member _.Invoke<'T>() =
                             tokens |> Seq.map (fun t -> fp.Parser t :?> 'T) |> Seq.toList :> _ }
 
                     let case = mkUnionCase caseInfo caseInfo.Tag ParseSource.AppSettings name [|results|]

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -47,7 +47,7 @@ type ArguException internal (message : string, exn : Exception) =
 /// Parse exception raised by Argu
 type ArguParseException internal (message : string, errorCode : ErrorCode) =
     inherit ArguException(message)
-    member __.ErrorCode = errorCode
+    member _.ErrorCode = errorCode
 
 /// An interface for error handling in the argument parser
 type IExiter =
@@ -59,8 +59,8 @@ type IExiter =
 /// Handles argument parser errors by raising an exception
 type ExceptionExiter() =
     interface IExiter with
-        member __.Name = "ArguException Exiter"
-        member __.Exit(msg, errorCode) = raise (new ArguParseException(msg, errorCode))
+        member _.Name = "ArguException Exiter"
+        member _.Exit(msg, errorCode) = raise (ArguParseException(msg, errorCode))
 
 /// Handles argument parser errors by exiting the process
 /// after printing a parse error.
@@ -71,15 +71,15 @@ type ProcessExiter(colorizerOption : (ErrorCode -> ConsoleColor option) option) 
         | Some color ->
             let previous = Console.ForegroundColor
             Console.ForegroundColor <- color
-            { new IDisposable with member __.Dispose() = Console.ForegroundColor <- previous }
+            { new IDisposable with member _.Dispose() = Console.ForegroundColor <- previous }
 
     // Note: this ctor is required to preserve binary compatibility with < 3.7
     new () = ProcessExiter(None)
-    new (colorizer : (ErrorCode -> ConsoleColor option)) = ProcessExiter(Some colorizer)
+    new (colorizer : ErrorCode -> ConsoleColor option) = ProcessExiter(Some colorizer)
 
     interface IExiter with
-        member __.Name = "Process Exiter"
-        member __.Exit(msg : string, errorCode : ErrorCode) =
+        member _.Name = "Process Exiter"
+        member _.Exit(msg : string, errorCode : ErrorCode) =
             let writer = if errorCode = ErrorCode.HelpText then Console.Out else Console.Error
             do
                 use _d = colorize errorCode

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -312,7 +312,7 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
         | OptionalParam(existential, parser) ->
             let optional =
                 existential.Accept { new IFunc<obj option> with
-                    member __.Invoke<'T> () = fields[0] :?> 'T option |> Option.map box }
+                    member _.Invoke<'T> () = fields[0] :?> 'T option |> Option.map box }
 
             match optional with
             | None -> yield clName()
@@ -395,7 +395,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
 
             | ListParam(ex,fp) ->
                 ex.Accept { new IFunc<XNode []> with
-                    member __.Invoke<'T> () =
+                    member _.Invoke<'T> () =
                         let values =
                             getFields().[0] :?> 'T list
                             |> Seq.map (fun t -> fp.UnParser (t :> _))
@@ -407,7 +407,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
 
             | OptionalParam(ex,fp) ->
                 ex.Accept { new IFunc<XNode []> with
-                    member __.Invoke<'T> () =
+                    member _.Invoke<'T> () =
                         let value =
                             match getFields().[0] :?> 'T option with
                             | None -> ""

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -2,11 +2,7 @@
 module internal Argu.UnParsers
 
 open System
-open System.Text
-open System.Xml
 open System.Xml.Linq
-
-open FSharp.Reflection
 
 /// Number of spaces to be inserted before a cli switch name in the usage string
 let [<Literal>] switchOffset = 4
@@ -17,7 +13,7 @@ let [<Literal>] descriptionOffset = 26
 ///     print the command line syntax
 /// </summary>
 let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : int) (programName : string) = stringExpr {
-    do if maxWidth < 1 then raise <| new ArgumentOutOfRangeException("maxWidth", "must be positive value.")
+    do if maxWidth < 1 then raise <| ArgumentOutOfRangeException("maxWidth", "must be positive value.")
     let! length0 = StringExpr.currentLength
     yield prefix
     yield programName
@@ -67,10 +63,10 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
             | Primitives parsers ->
                 match aI.CustomAssignmentSeparator.Value with
                 | Some {Separator = sep} when parsers.Length = 1 ->
-                    yield sprintf "%s<%s>" sep parsers.[0].Description
+                    yield sprintf "%s<%s>" sep parsers[0].Description
                 | Some {Separator = sep} ->
                     assert(parsers.Length = 2)
-                    yield sprintf " <%s>%s<%s>" parsers.[0].Description sep parsers.[1].Description
+                    yield sprintf " <%s>%s<%s>" parsers[0].Description sep parsers[1].Description
                 | None ->
                     for p in parsers do
                         yield sprintf " <%s>" p.Description
@@ -113,9 +109,9 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
             match mc.ParameterInfo.Value with
             | Primitives parsers ->
                 assert(parsers.Length > 0)
-                yield sprintf "<%s>" parsers.[0].Description
+                yield sprintf "<%s>" parsers[0].Description
                 for i = 1 to parsers.Length - 1 do
-                    yield sprintf " <%s>" parsers.[i].Description
+                    yield sprintf " <%s>" parsers[i].Description
 
             | ListParam(_, parser) ->
                 yield sprintf "<%s>..." parser.Description
@@ -140,19 +136,19 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
     match aI.ParameterInfo.Value with
     | Primitives parsers when aI.IsMainCommand ->
         assert(parsers.Length > 0)
-        yield sprintf "<%s>" parsers.[0].Description
+        yield sprintf "<%s>" parsers[0].Description
         for i = 1 to parsers.Length - 1 do
-            yield sprintf " <%s>" parsers.[i].Description
+            yield sprintf " <%s>" parsers[i].Description
 
         if aI.IsRest.Value then yield "..."
 
     | Primitives parsers ->
         match aI.CustomAssignmentSeparator.Value with
         | Some {Separator = sep} when parsers.Length = 1 ->
-            yield sprintf "%s<%s>" sep parsers.[0].Description
+            yield sprintf "%s<%s>" sep parsers[0].Description
         | Some {Separator = sep} ->
             assert (parsers.Length = 2)
-            yield sprintf " <%s>%s<%s>" parsers.[0].Description sep parsers.[1].Description
+            yield sprintf " <%s>%s<%s>" parsers[0].Description sep parsers[1].Description
         | None ->
             for p in parsers do
                 yield sprintf " <%s>" p.Description
@@ -298,7 +294,7 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
 
         match aI.ParameterInfo.Value with
         | Primitives parsers ->
-            let inline unpars i = parsers.[i].UnParser fields.[i]
+            let inline unpars i = parsers[i].UnParser fields[i]
             match aI.CustomAssignmentSeparator.Value with
             | Some {Separator = sep} when parsers.Length = 1 ->
                 yield sprintf "%s%s%s" (clName()) sep (unpars 0)
@@ -316,7 +312,7 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
         | OptionalParam(existential, parser) ->
             let optional =
                 existential.Accept { new IFunc<obj option> with
-                    member __.Invoke<'T> () = fields.[0] :?> 'T option |> Option.map box }
+                    member __.Invoke<'T> () = fields[0] :?> 'T option |> Option.map box }
 
             match optional with
             | None -> yield clName()
@@ -327,18 +323,18 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
 
         | ListParam(_, parser) ->
             if not aI.IsMainCommand then yield clName()
-            let objSeq = fields.[0] |> unbox<System.Collections.IEnumerable> |> Seq.cast<obj>
+            let objSeq = fields[0] |> unbox<System.Collections.IEnumerable> |> Seq.cast<obj>
             for obj in objSeq do yield parser.UnParser obj
 
         | SubCommand (_, nested, _) ->
             if not aI.IsMainCommand then yield clName()
-            let nestedResult = fields.[0] :?> IParseResult
+            let nestedResult = fields[0] :?> IParseResult
             yield! mkCommandLineArgs nested (nestedResult.GetAllResults())
         | NullarySubCommand -> yield clName()
         }
 
     args
-    |> Seq.map (fun o -> let tag = argInfo.TagReader.Value o in argInfo.Cases.Value.[tag], o)
+    |> Seq.map (fun o -> let tag = argInfo.TagReader.Value o in argInfo.Cases.Value[tag], o)
     |> Seq.sortBy (fun (aI,_) -> aI.CliPosition.Value)
     |> Seq.collect (fun (aI,o) -> mkEntry aI o)
 
@@ -348,7 +344,7 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
 let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Template list) =
     let mkArgumentEntry (t : 'Template) : XNode [] =
         let tag = argInfo.TagReader.Value (t :> _)
-        let aI = argInfo.Cases.Value.[tag]
+        let aI = argInfo.Cases.Value[tag]
         let getFields () = aI.FieldReader.Value (t :> _)
 
         let mkElem (mkComment : unit -> string) (key : string) (value : string) : XNode [] =
@@ -375,7 +371,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
                     | fields ->
                         (fields, parsers)
                         ||> Seq.map2 (fun f p -> p.UnParser f)
-                        |> String.concat aI.AppSettingsSeparators.[0]
+                        |> String.concat aI.AppSettingsSeparators[0]
 
                 let mkComment () =
                     stringExpr {
@@ -388,7 +384,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
                             yield " : "
                             yield first.Description
                             for p in rest do
-                                yield aI.AppSettingsSeparators.[0]
+                                yield aI.AppSettingsSeparators[0]
                                 yield p.Description
 
                         yield ' '
@@ -403,7 +399,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
                         let values =
                             getFields().[0] :?> 'T list
                             |> Seq.map (fun t -> fp.UnParser (t :> _))
-                            |> String.concat aI.AppSettingsSeparators.[0]
+                            |> String.concat aI.AppSettingsSeparators[0]
 
                         let mkComment () = sprintf " %s : %s ..." aI.Description.Value fp.Description
 

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -122,7 +122,7 @@ with
     member inline __.IsCommandLineArg = match __.CommandLineNames.Value with [] -> __.IsMainCommand | _ -> true
     member inline __.IsCustomAssignment = Option.isSome __.CustomAssignmentSeparator.Value
 
-and ParameterInfo =
+and [<NoComparison; NoEquality>] ParameterInfo =
     | Primitives of FieldParserInfo []
     | OptionalParam of Existential * FieldParserInfo
     | ListParam of Existential * FieldParserInfo

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -118,9 +118,9 @@ type UnionCaseArgInfo =
         GatherAllSources : Lazy<bool>
     }
 with
-    member inline __.IsMainCommand = Option.isSome __.MainCommandName.Value
-    member inline __.IsCommandLineArg = match __.CommandLineNames.Value with [] -> __.IsMainCommand | _ -> true
-    member inline __.IsCustomAssignment = Option.isSome __.CustomAssignmentSeparator.Value
+    member inline x.IsMainCommand = Option.isSome x.MainCommandName.Value
+    member inline x.IsCommandLineArg = match x.CommandLineNames.Value with [] -> x.IsMainCommand | _ -> true
+    member inline x.IsCustomAssignment = Option.isSome x.CustomAssignmentSeparator.Value
 
 and [<NoComparison; NoEquality>] ParameterInfo =
     | Primitives of FieldParserInfo []
@@ -189,10 +189,9 @@ type UnionCaseParseResult =
         /// parse source
         Source : ParseSource
     }
-with
-    member inline __.Tag = __.CaseInfo.Tag
-    member inline __.Value = __.CaseInfo.CaseCtor.Value __.Fields
-    member inline __.FieldContents = __.CaseInfo.FieldCtor.Value __.Fields
+    member inline x.Tag = x.CaseInfo.Tag
+    member inline x.Value = x.CaseInfo.CaseCtor.Value x.Fields
+    member inline x.FieldContents = x.CaseInfo.FieldCtor.Value x.Fields
 
 [<NoEquality; NoComparison>]
 type UnionParseResults =

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -264,10 +264,10 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
         |> Array.unzip
 
     /// Gets the value corresponding to supplied key
-    member __.Item(key : string) =
+    member x.Item(key : string) =
         let mutable kr = null
         let mutable vr = Unchecked.defaultof<_>
-        if __.TryGetPrefix(key, &kr, &vr) && kr = key then vr
+        if x.TryGetPrefix(key, &kr, &vr) && kr = key then vr
         else
             raise <| KeyNotFoundException(key)
 

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -5,24 +5,22 @@ open System
 open System.Collections.Generic
 open System.Reflection
 open System.Text
-open System.Text.RegularExpressions
 
-open FSharp.Reflection
 open FSharp.Quotations
 open FSharp.Quotations.Patterns
 open System.Collections
 
 let allBindings = BindingFlags.NonPublic ||| BindingFlags.Public ||| BindingFlags.Static ||| BindingFlags.Instance
 
-let inline arguExn fmt = Printf.ksprintf(fun msg -> raise <| new ArguException(msg)) fmt
+let inline arguExn fmt = Printf.ksprintf(fun msg -> raise <| ArguException(msg)) fmt
 
-let inline arguExnChain exn fmt = Printf.ksprintf(fun msg -> raise <| new ArguException(msg, exn)) fmt
+let inline arguExnChain exn fmt = Printf.ksprintf(fun msg -> raise <| ArguException(msg, exn)) fmt
 
 /// get CL arguments from environment
 let getEnvironmentCommandLineArgs () =
-    match System.Environment.GetCommandLineArgs() with
+    match Environment.GetCommandLineArgs() with
     | [||] -> [||]
-    | args -> args.[1..]
+    | args -> args[1..]
 
 [<RequireQualifiedAccess>]
 module Enum =
@@ -35,12 +33,12 @@ module Array =
     let last (ts : 'T[]) =
         match ts.Length with
         | 0 -> invalidArg "xs" "input array is empty."
-        | n -> ts.[n - 1]
+        | n -> ts[n - 1]
 
     let tryLast (ts : 'T[]) =
         match ts.Length with
         | 0 -> None
-        | n -> Some ts.[n-1]
+        | n -> Some ts[n-1]
 
 [<RequireQualifiedAccess>]
 module List =
@@ -78,7 +76,7 @@ module Seq =
 
 [<RequireQualifiedAccess>]
 module String =
-    let inline mkWhiteSpace (length : int) = new String(' ', length)
+    let inline mkWhiteSpace (length : int) = String(' ', length)
 
 [<AbstractClass>]
 type Existential internal () =
@@ -91,8 +89,8 @@ type Existential internal () =
 
 and Existential<'T> () =
     inherit Existential()
-    override __.Type = typeof<'T>
-    override __.Accept func = func.Invoke<'T>()
+    override _.Type = typeof<'T>
+    override _.Accept func = func.Invoke<'T>()
 
 and IFunc<'R> =
     abstract Invoke<'T> : unit -> 'R
@@ -108,8 +106,8 @@ type ShapeArgumentTemplate() =
 
 and ShapeArgumentTemplate<'Template when 'Template :> IArgParserTemplate>() =
     inherit ShapeArgumentTemplate()
-    override __.Type = typeof<'Template>
-    override __.Accept func = func.Invoke<'Template>()
+    override _.Type = typeof<'Template>
+    override _.Accept func = func.Invoke<'Template>()
 
 and ITemplateFunc<'R> =
     abstract Invoke<'Template when 'Template :> IArgParserTemplate> : unit -> 'R
@@ -119,7 +117,7 @@ type Unchecked =
     static member UntypedDefaultOf(t : Type) =
         Existential.FromType(t).Accept {
             new IFunc<obj> with
-                member __.Invoke<'T> () = Unchecked.defaultof<'T> :> obj
+                member _.Invoke<'T> () = Unchecked.defaultof<'T> :> obj
             }
 
 type MemberInfo with
@@ -137,7 +135,7 @@ type IDictionary<'K,'V> with
         if ok then Some found
         else None
 
-let currentProgramName = lazy(System.Diagnostics.Process.GetCurrentProcess().MainModule.ModuleName)
+let currentProgramName = lazy System.Diagnostics.Process.GetCurrentProcess().MainModule.ModuleName
 
 /// recognize exprs that strictly contain DU constructors
 /// e.g. <@ Case @> is valid but <@ fun x y -> Case y x @> is invalid
@@ -198,7 +196,7 @@ let escapeCliString (value : string) =
                             * N backslashes ==> N backslashes
                         *)
                         let nextCharAfterBackslashes = value |> Seq.skip (i + 1) |> Seq.filter (fun c -> c <> '\\') |> Seq.tryFirst
-                        if nextCharAfterBackslashes = Some ('"') || nextCharAfterBackslashes = None then
+                        if nextCharAfterBackslashes = Some '"' || nextCharAfterBackslashes = None then
                             yield '\\'
                             yield '\\'
                         else
@@ -222,32 +220,32 @@ let flattenCliTokens (tokens : seq<string>) =
 type StringExpr<'T> = StringBuilder -> 'T
 
 type StringExprBuilder () =
-    member __.Zero () : StringExpr<unit> = ignore
-    member __.Bind(f : StringExpr<'T>, g : 'T -> StringExpr<'S>) : StringExpr<'S> =
+    member _.Zero () : StringExpr<unit> = ignore
+    member _.Bind(f : StringExpr<'T>, g : 'T -> StringExpr<'S>) : StringExpr<'S> =
         fun sb -> g (f sb) sb
 
-    member __.Yield (txt : string) : StringExpr<unit> = fun b -> b.Append txt |> ignore
-    member __.Yield (c : char) : StringExpr<unit> = fun b -> b.Append c |> ignore
-    member __.YieldFrom (f : StringExpr<unit>) = f
+    member _.Yield (txt : string) : StringExpr<unit> = fun b -> b.Append txt |> ignore
+    member _.Yield (c : char) : StringExpr<unit> = fun b -> b.Append c |> ignore
+    member _.YieldFrom (f : StringExpr<unit>) = f
 
-    member __.Combine(f : StringExpr<unit>, g : StringExpr<'T>) : StringExpr<'T> = fun b -> f b; g b
-    member __.Delay (f : unit -> StringExpr<'T>) : StringExpr<'T> = fun b -> f () b
+    member _.Combine(f : StringExpr<unit>, g : StringExpr<'T>) : StringExpr<'T> = fun b -> f b; g b
+    member _.Delay (f : unit -> StringExpr<'T>) : StringExpr<'T> = fun b -> f () b
 
-    member __.For (xs : 'a seq, f : 'a -> StringExpr<unit>) : StringExpr<unit> =
+    member _.For (xs : 'a seq, f : 'a -> StringExpr<unit>) : StringExpr<unit> =
         fun b ->
             use e = xs.GetEnumerator ()
             while e.MoveNext() do f e.Current b
 
-    member __.While (p : unit -> bool, f : StringExpr<unit>) : StringExpr<unit> =
+    member _.While (p : unit -> bool, f : StringExpr<unit>) : StringExpr<unit> =
         fun b -> while p () do f b
 
-let stringExpr = new StringExprBuilder ()
+let stringExpr = StringExprBuilder()
 
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module StringExpr =
     let build (f : StringExpr<unit>) =
-        let b = new StringBuilder ()
+        let b = StringBuilder()
         do f b
         b.ToString ()
 
@@ -271,16 +269,16 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
         let mutable vr = Unchecked.defaultof<_>
         if __.TryGetPrefix(key, &kr, &vr) && kr = key then vr
         else
-            raise <| new KeyNotFoundException(key)
+            raise <| KeyNotFoundException(key)
 
     /// Look up best matching key entry by prefix
-    member __.TryGetPrefix(value : string, kresult : byref<string>, vresult : byref<'Value>) : bool =
+    member _.TryGetPrefix(value : string, kresult : byref<string>, vresult : byref<'Value>) : bool =
         // Just iterate through all the keys, picking the matching prefix
         // with the maximal length
         let mutable maxPos = -1
         let mutable maxLen = -1
         for i = 0 to keys.Length - 1 do
-            let key = keys.[i]
+            let key = keys[i]
             let pLength =
                 if value.StartsWith(key, StringComparison.Ordinal) then key.Length
                 else -1
@@ -290,12 +288,12 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
                 maxLen <- pLength
 
         if maxPos < 0 then false
-        else kresult <- keys.[maxPos] ; vresult <- values.[maxPos] ; true
+        else kresult <- keys[maxPos] ; vresult <- values[maxPos] ; true
 
-    member __.Count with get(): int = keys.Length
+    member _.Count with get(): int = keys.Length
     interface IEnumerable<string * 'Value> with
-        member __.GetEnumerator() = keyVals.GetEnumerator()
-        member __.GetEnumerator() = keyVals.GetEnumerator() :> IEnumerator
+        member _.GetEnumerator() = keyVals.GetEnumerator()
+        member _.GetEnumerator() = keyVals.GetEnumerator() :> IEnumerator
 
 /// Gets the default width of the current console window,
 /// if available.
@@ -307,14 +305,14 @@ let wordwrap (width:int) (inputText:string) =
     let breakLine (text:string) (pos:int) (max:int) =
         // Find last whitespace in line
         let mutable i = max - 1
-        while i >= 0 && not (Char.IsWhiteSpace text.[pos + i]) do
+        while i >= 0 && not (Char.IsWhiteSpace text[pos + i]) do
             i <- i - 1
 
         if i < 0 then
             max // No whitespace found; break at maximum length
         else
             // Find start of whitespace
-            while i >= 0 && Char.IsWhiteSpace text.[pos + i] do
+            while i >= 0 && Char.IsWhiteSpace text[pos + i] do
                 i <- i - 1
             // Return length of text before whitespace
             i + 1
@@ -322,7 +320,7 @@ let wordwrap (width:int) (inputText:string) =
     if width < 1 then invalidArg "width" "Must be positive number."
 
     let inputText = inputText.Replace("\r\n","\n").Replace("\r","\n")
-    let lines = new ResizeArray<string>()
+    let lines = ResizeArray<string>()
     // Parse each line of text
     let mutable pos = 0
     let mutable next = 0
@@ -345,12 +343,12 @@ let wordwrap (width:int) (inputText:string) =
                 if len > width then
                     len <- breakLine inputText pos width
 
-                inputText.[pos .. pos + len - 1] |> lines.Add
+                inputText[pos .. pos + len - 1] |> lines.Add
 
                 // Trim whitespace following break
                 pos <- pos + len
 
-                while pos < eol && Char.IsWhiteSpace inputText.[pos] do
+                while pos < eol && Char.IsWhiteSpace inputText[pos] do
                     pos <- pos + 1
 
         pos <- next

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -13,8 +13,8 @@ open Argu
 module ``Argu Tests Main List`` =
 
     type Exception with
-        member inline __.FirstLine = 
-            __.Message.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries).[0]
+        member inline x.FirstLine = 
+            x.Message.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries).[0]
 
     [<Flags>]
     type Enum =
@@ -30,7 +30,6 @@ module ``Argu Tests Main List`` =
     type PushArgs =
         | [<AltCommandLine("-f")>] Force
         | [<MainCommand("COMMAND"); ExactlyOnce>] Remote of repo_name:string * branch_name:string
-    with
         interface IArgParserTemplate with
             member this.Usage = 
                 match this with
@@ -39,7 +38,6 @@ module ``Argu Tests Main List`` =
 
     type NewArgs =
         | [<Mandatory>] Name of string
-    with
         interface IArgParserTemplate with
             member this.Usage = 
                 match this with
@@ -47,7 +45,6 @@ module ``Argu Tests Main List`` =
 
     type TagArgs =
         | New of ParseResults<NewArgs>
-    with
         interface IArgParserTemplate with
             member this.Usage = 
                 match this with
@@ -55,7 +52,6 @@ module ``Argu Tests Main List`` =
 
     type CheckoutArgs =
         | [<Mandatory>] Branch of string
-    with
         interface IArgParserTemplate with
             member this.Usage = 
                 match this with
@@ -66,7 +62,6 @@ module ``Argu Tests Main List`` =
         | D
         | F
         | X
-    with
         interface IArgParserTemplate with
             member this.Usage = "clean"
 
@@ -75,7 +70,6 @@ module ``Argu Tests Main List`` =
         | Foo
         | [<CliPrefix(CliPrefix.None)>] Sub of ParseResults<CleanArgs>
         | [<SubCommand; CliPrefix(CliPrefix.None)>] Null_Sub
-    with
         interface IArgParserTemplate with
             member this.Usage = "required"
 
@@ -83,7 +77,6 @@ module ``Argu Tests Main List`` =
         | Switch1
         | Switch2
         | [<GatherUnrecognized; Hidden>] Unrec of values:string
-    with
         interface IArgParserTemplate with
             member this.Usage = "gus"
 
@@ -124,7 +117,6 @@ module ``Argu Tests Main List`` =
         | [<CliPrefix(CliPrefix.None)>] Required of ParseResults<RequiredSubcommand>
         | [<CliPrefix(CliPrefix.None)>] Unrecognized of ParseResults<GatherUnrecognizedSubcommand>
         | [<SubCommand; CliPrefix(CliPrefix.None)>] Nullary_Sub
-    with
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
@@ -276,7 +268,6 @@ module ``Argu Tests Main List`` =
     // will incorrectly
     type LocaleTurkish =
         | Install of bool
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -394,7 +385,6 @@ module ``Argu Tests Main List`` =
     
     type DisallowedAssignmentArgs =
     | [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
-    with
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
@@ -406,7 +396,6 @@ module ``Argu Tests Main List`` =
         
     type DisallowedArityWithAssignmentOrSpaced =
     | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string * int
-    with
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
@@ -696,45 +685,38 @@ module ``Argu Tests Main List`` =
     type ConflictingCliNames =
         | [<CustomCommandLine "foo">] Foo of int
         | [<AltCommandLine "foo">] Bar of string
-    with
         interface IArgParserTemplate with
             member a.Usage = "foo"
 
     type ConflictingAppSettingsNames =
         | [<CustomAppSettings "foo">]Foo of int
         | [<CustomAppSettings "foo">] Bar of string
-    with
         interface IArgParserTemplate with
             member a.Usage = "foo"
 
     type ConflictingInheritedCliName =
         | [<AltCommandLine("-f"); Inherit>] Force
         | Nested of ParseResults<CleanArgs>
-    with
         interface IArgParserTemplate with
             member _.Usage = "not tested"
 
     type RecursiveArgument1 =
         | Rec1 of ParseResults<RecursiveArgument2>
-    with
         interface IArgParserTemplate with
             member a.Usage = "foo"
 
     and RecursiveArgument2 =
         | Rec2 of ParseResults<RecursiveArgument3>
-    with
         interface IArgParserTemplate with
             member a.Usage = "bar"
 
     and RecursiveArgument3 =
         | Rec3 of ParseResults<RecursiveArgument1>
-    with
         interface IArgParserTemplate with
             member a.Usage = "baz"
 
     type GenericArgument<'T> =
         | Bar of 'T
-    with
         interface IArgParserTemplate with
             member a.Usage = "baz"
 
@@ -768,7 +750,6 @@ module ``Argu Tests Main List`` =
     type ArgumentSingleDash =
         | Argument of string
         | Levels_Deep of int
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -792,7 +773,6 @@ module ``Argu Tests Main List`` =
     type ArgumentNoDash =
         | Argument of string
         | Levels_Deep of int
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -837,7 +817,6 @@ module ``Argu Tests Main List`` =
     type ArgumentWithAltHelp =
         | AltHelp1 of string
         | AltHelp2 of int
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -845,7 +824,6 @@ module ``Argu Tests Main List`` =
     type NoHelp =
         | NoHelp1 of string
         | NoHelp2 of int
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -875,7 +853,6 @@ module ``Argu Tests Main List`` =
     [<DisableHelpFlags>]
     type NestedInherited =
         | [<Inherit>] Nested of ParseResults<NoHelp>
-    with
         interface IArgParserTemplate with
             member a.Usage = "not tested here"
 
@@ -896,7 +873,6 @@ module ``Argu Tests Main List`` =
 
     type SubCommand =
         | SubParameter
-    with
         interface IArgParserTemplate with
             member this.Usage =
                 match this with
@@ -905,7 +881,6 @@ module ``Argu Tests Main List`` =
     type BaseCommand =
         | [<Inherit;Hidden>] BaseParameter
         | [<CustomCommandLine("sub")>] Sub of ParseResults<SubCommand>
-    with
         interface IArgParserTemplate with
             member this.Usage =
                 match this with
@@ -930,8 +905,8 @@ module ``Argu Tests Main List`` =
 module ``Argu Tests Main Primitive`` =
 
     type Exception with
-        member inline __.FirstLine = 
-            __.Message.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries).[0]
+        member inline x.FirstLine = 
+            x.Message.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries).[0]
 
     type ArgumentPrimitive =
       | [<AltCommandLine("-v"); Inherit>] Verbose
@@ -952,7 +927,6 @@ module ``Argu Tests Main Primitive`` =
       | [<Last>] Last_Parameter of string
       | Optional of int option
       | List of int list
-    with
       interface IArgParserTemplate with
           member a.Usage =
               match a with

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -128,7 +128,7 @@ module ``Argu Tests Main List`` =
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
-                | Verbose _ -> "be verbose."
+                | Verbose -> "be verbose."
                 | Working_Directory _ -> "specify a working directory."
                 | Listener _ -> "specify a listener."
                 | Mandatory_Arg _ -> "a mandatory argument."
@@ -143,7 +143,7 @@ module ``Argu Tests Main List`` =
                 | Float32_Arg _ -> "Some float32"
                 | Float64_Arg _ -> "Some float64"
                 | Decimal_Arg _ -> "Some decimal"
-                | Detach _ -> "detach daemon from console."
+                | Detach -> "detach daemon from console."
                 | Assignment _ -> "assign with colon operation."
                 | Enum _ -> "assign from three possible values."
                 | Enumeration _ -> "assign from three possible values."
@@ -167,7 +167,7 @@ module ``Argu Tests Main List`` =
     let parseFunc ignoreMissing f = parser.ParseConfiguration(ConfigurationReader.FromFunction f, ignoreMissing)
 
     [<Fact>]
-    let ``Numberic decimal separators parsing is culture invariant``() =
+    let ``Numeric decimal separators parsing is culture invariant``() =
         CultureInfo.CurrentUICulture <- CultureInfo.CurrentUICulture.Clone() :?> CultureInfo
         CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator <- ","
 
@@ -219,9 +219,9 @@ module ``Argu Tests Main List`` =
         let xmlSource = parser.PrintAppSettingsArguments args
         let usages = List.map (fun a -> (a :> IArgParserTemplate).Usage) args
         
-        test <@ xmlSource.Contains usages.[0] = true @>
-        test <@ xmlSource.Contains usages.[1] = true @>
-        test <@ xmlSource.Contains usages.[2] = true @>
+        test <@ xmlSource.Contains usages[0] = true @>
+        test <@ xmlSource.Contains usages[1] = true @>
+        test <@ xmlSource.Contains usages[2] = true @>
 
     [<Fact>]
     let ``AppSettings CSV parsing`` () =
@@ -284,7 +284,7 @@ module ``Argu Tests Main List`` =
     let ``CLIArguments Locale`` () =
         let originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture
         try
-            System.Threading.Thread.CurrentThread.CurrentCulture <- new System.Globalization.CultureInfo("tr-TR")
+            System.Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo("tr-TR")
             let parser2 = ArgumentParser.Create<LocaleTurkish> (programName = "gadget")
             let result = parser2.ParseCommandLine([| "--install"; "true" |], ignoreMissing = true)
             test <@ result.GetResult <@ Install @> @>
@@ -302,7 +302,7 @@ module ``Argu Tests Main List`` =
                                         (fun e -> <@ e.Message.Contains "more than once" @>)
 
     [<Fact>]
-    let ``First Parameter not placed at beggining`` () =
+    let ``First Parameter not placed at beginning`` () =
         raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
                                         (fun e -> <@ e.Message.Contains "should precede all other" @>)
                                         
@@ -712,7 +712,7 @@ module ``Argu Tests Main List`` =
         | Nested of ParseResults<CleanArgs>
     with
         interface IArgParserTemplate with
-            member __.Usage = "not tested"
+            member _.Usage = "not tested"
 
     type RecursiveArgument1 =
         | Rec1 of ParseResults<RecursiveArgument2>
@@ -888,7 +888,7 @@ module ``Argu Tests Main List`` =
     let ``Fail on malformed case constructors`` () =
         let result = parser.ToParseResults []
         let wrapper = List
-        raises<ArgumentException> <@ result.Contains <@ fun (y : string) -> Log_Level 42 @> @>
+        raises<ArgumentException> <@ result.Contains <@ fun (_y : string) -> Log_Level 42 @> @>
         raises<ArgumentException> <@ result.Contains <@ fun (y, x) -> Data(x,y) @> @>
         raises<ArgumentException> <@ result.Contains <@ fun x -> () ; Log_Level x @> @>
         raises<ArgumentException> <@ result.Contains <@ let wrapper = List in wrapper @> @>
@@ -910,7 +910,7 @@ module ``Argu Tests Main List`` =
             member this.Usage =
                 match this with
                 | BaseParameter -> "will be hidden"
-                | Sub(_) -> "subcommand"
+                | Sub _ -> "subcommand"
 
     [<Fact>]
     let ``Hidden parameters are not printed in help text`` () =
@@ -926,10 +926,6 @@ module ``Argu Tests Main List`` =
             test <@ r.Parser.PrintUsage().Contains "will be shown" @>
             test <@ r.Parser.PrintUsage().Contains "will be hidden" |> not @>
         | _ -> failwithf "never should get here"
-
-
-
-
 
 module ``Argu Tests Main Primitive`` =
 
@@ -960,7 +956,7 @@ module ``Argu Tests Main Primitive`` =
       interface IArgParserTemplate with
           member a.Usage =
               match a with
-              | Verbose _ -> "be verbose."
+              | Verbose -> "be verbose."
               | Working_Directory _ -> "specify a working directory."
               | Listener _ -> "specify a listener."
               | Mandatory_Arg _ -> "a mandatory argument."
@@ -969,7 +965,7 @@ module ``Argu Tests Main Primitive`` =
               | Data _ -> "pass raw data in base64 format."
               | Dir _ -> "Project directory to place the config & database in."
               | Log_Level _ -> "set the log level."
-              | Detach _ -> "detach daemon from console."
+              | Detach -> "detach daemon from console."
               | Assignment _ -> "assign with colon operation."
               | Env _ -> "assign environment variables."
               | Main _ -> "main command."
@@ -1004,7 +1000,7 @@ module ``Argu Tests Main Primitive`` =
                                         (fun e -> <@ e.Message.Contains "USAGE:" @>)
     
     [<Fact>]
-    let ``First Parameter not placed at beggining`` () =
+    let ``First Parameter not placed at beginning`` () =
         raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
                                         (fun e -> <@ e.Message.Contains "should precede all other" @>)
 

--- a/tests/Argu.Tests/tests.fsx
+++ b/tests/Argu.Tests/tests.fsx
@@ -1,10 +1,9 @@
-﻿#I "../../bin/Debug/net40/"
+﻿#I "bin/Debug/net6.0/"
 #r "Argu.dll"
 #r "Argu.Tests.dll"
 
 open System
 open Argu
-open Argu.Tests
 
 type MyEnum =
     | First


### PR DESCRIPTION
Warning level 5
fix typos
track lang changes (`__.`->`_.`, remove redundant `.` in `.[]` etc)