### PR TITLE
chore: Set Git identity for gh-pages commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
       - name: Build


### PR DESCRIPTION
The git identity needs to be set in https://github.com/fsprojects/Argu/actions/runs/7181861887/job/19557118490

Because a commit is being pushed to the `gh-pages` branch.