### PR TITLE
fix(Release): Inhibit packing of LS sample

### DIFF
--- a/samples/Argu.Samples.LS/Argu.Samples.LS.fsproj
+++ b/samples/Argu.Samples.LS/Argu.Samples.LS.fsproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>ls</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Arguments.fs" />


### PR DESCRIPTION
Sets `IsPackable` to `false` for the LS sample
In order to inhibit production of a `.nupkg` for it (which the NuGet push action then proceeds to [attempt to] push)

re https://github.com/fsprojects/Argu/issues/189#issuecomment-1853681150