### PR TITLE
fix: Remove incorrect Dotnet.ReproducibleBuilds ref

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
-### 6.1.3
+### 6.1.4
+* Fix: remove incorrect `ReproducibleBuilds` reference [introduced in `6.1.3`](https://github.com/fsprojects/Argu/pull/174)
+
+### 6.1.3 (Unlisted)
 * Add ParseResults.GetResult(expr, unit -> 'T) helper for Catch [#187](https://github.com/fsprojects/Argu/pull/187)
+* Use [`Dotnet.ReproducibleBuilds`](https://github.com/dotnet/reproducible-builds) [#174](https://github.com/fsprojects/Argu/pull/174)
 
 ### 6.1.2
 * Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116) [@chestercodes](https://github.com/chestercodes) 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### 6.1.4
-* Fix: remove incorrect `ReproducibleBuilds` reference [introduced in `6.1.3`](https://github.com/fsprojects/Argu/pull/174)
+* Fix: remove incorrect `ReproducibleBuilds` reference [introduced in `6.1.3`](https://github.com/fsprojects/Argu/pull/174) [#202](https://github.com/fsprojects/Argu/pull/202)
 
 ### 6.1.3 (Unlisted)
 * Add ParseResults.GetResult(expr, unit -> 'T) helper for Catch [#187](https://github.com/fsprojects/Argu/pull/187)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.402",
-    "rollForward": "minor"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.402",
-    "rollForward": "latestMajor"
+    "rollForward": "minor"
   }
 }

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,6 @@ storage: none
 
 nuget FSharp.Core >= 4.3.2 lowest_matching:true
 nuget System.Configuration.ConfigurationManager >= 4.0 lowest_matching:true
-nuget DotNet.ReproducibleBuilds copy_local: true
 
 group Tests
   source https://api.nuget.org/v3/index.json

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ storage: none
 
 nuget FSharp.Core >= 4.3.2 lowest_matching:true
 nuget System.Configuration.ConfigurationManager >= 4.0 lowest_matching:true
-nuget DotNet.ReproducibleBuilds
+nuget DotNet.ReproducibleBuilds copy_local: true
 
 group Tests
   source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,24 +2,24 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    DotNet.ReproducibleBuilds (1.1.1)
+    DotNet.ReproducibleBuilds (1.1.1) - copy_local: true
       Microsoft.SourceLink.AzureRepos.Git (>= 1.1.1)
       Microsoft.SourceLink.Bitbucket.Git (>= 1.1.1)
       Microsoft.SourceLink.GitHub (>= 1.1.1)
       Microsoft.SourceLink.GitLab (>= 1.1.1)
     FSharp.Core (4.3.2)
-    Microsoft.Build.Tasks.Git (8.0)
-    Microsoft.SourceLink.AzureRepos.Git (8.0)
+    Microsoft.Build.Tasks.Git (8.0) - copy_local: true
+    Microsoft.SourceLink.AzureRepos.Git (8.0) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 8.0)
       Microsoft.SourceLink.Common (>= 8.0)
-    Microsoft.SourceLink.Bitbucket.Git (8.0)
+    Microsoft.SourceLink.Bitbucket.Git (8.0) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 8.0)
       Microsoft.SourceLink.Common (>= 8.0)
-    Microsoft.SourceLink.Common (8.0)
-    Microsoft.SourceLink.GitHub (1.1.1)
+    Microsoft.SourceLink.Common (8.0) - copy_local: true
+    Microsoft.SourceLink.GitHub (1.1.1) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 1.1.1)
       Microsoft.SourceLink.Common (>= 1.1.1)
-    Microsoft.SourceLink.GitLab (8.0)
+    Microsoft.SourceLink.GitLab (8.0) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 8.0)
       Microsoft.SourceLink.Common (>= 8.0)
     System.Buffers (4.5.1)

--- a/paket.lock
+++ b/paket.lock
@@ -2,26 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    DotNet.ReproducibleBuilds (1.1.1) - copy_local: true
-      Microsoft.SourceLink.AzureRepos.Git (>= 1.1.1)
-      Microsoft.SourceLink.Bitbucket.Git (>= 1.1.1)
-      Microsoft.SourceLink.GitHub (>= 1.1.1)
-      Microsoft.SourceLink.GitLab (>= 1.1.1)
     FSharp.Core (4.3.2)
-    Microsoft.Build.Tasks.Git (8.0) - copy_local: true
-    Microsoft.SourceLink.AzureRepos.Git (8.0) - copy_local: true
-      Microsoft.Build.Tasks.Git (>= 8.0)
-      Microsoft.SourceLink.Common (>= 8.0)
-    Microsoft.SourceLink.Bitbucket.Git (8.0) - copy_local: true
-      Microsoft.Build.Tasks.Git (>= 8.0)
-      Microsoft.SourceLink.Common (>= 8.0)
-    Microsoft.SourceLink.Common (8.0) - copy_local: true
-    Microsoft.SourceLink.GitHub (1.1.1) - copy_local: true
-      Microsoft.Build.Tasks.Git (>= 1.1.1)
-      Microsoft.SourceLink.Common (>= 1.1.1)
-    Microsoft.SourceLink.GitLab (8.0) - copy_local: true
-      Microsoft.Build.Tasks.Git (>= 8.0)
-      Microsoft.SourceLink.Common (>= 8.0)
     System.Buffers (4.5.1)
     System.Configuration.ConfigurationManager (4.4)
       System.Security.Cryptography.ProtectedData (>= 4.4)

--- a/src/Argu/Argu.fsproj
+++ b/src/Argu/Argu.fsproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -20,6 +21,10 @@
     <Compile Include="ArgumentParser.fs" />
     <None Include="paket.references" />
     <None Include="..\..\resource\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- SourceLink etc -->
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Argu/paket.references
+++ b/src/Argu/paket.references
@@ -1,3 +1,2 @@
 ﻿FSharp.Core
 System.Configuration.ConfigurationManager
-DotNet.ReproducibleBuilds


### PR DESCRIPTION
[Version 6.1.3](https://www.nuget.org/packages/Argu/6.1.3#dependencies-body-tab) has an incorrect additional reference

~Per https://github.com/fsprojects/Paket/issues/2951 this should remove that...~ Resolved by using a `PackageReference` rather than fighting `paket` on this one