### PR TITLE
feat(ArgumentParser): Expose ProgramName

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 6.2.0
+* Add `ParseResults.ProgramName` [#229](https://github.com/fsprojects/Argu/pull/229)
+
 ### 6.1.5
 * Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix Mandatory arguments in nested subcommands. [#220](https://github.com/fsprojects/Argu/issues/220) [@fpellet](https://github.com/fpellet)
 

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -115,6 +115,9 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
             | _ -> argInfoWithCheck.Value
         new ArgumentParser<'Template>(argInfo, programName, helpTextMessage, usageStringCharacterWidth, errorHandler)
 
+    /// <summary>The Program Name, as used when rendering help messages. Can be overridden via the <c>programName</c> constructor argument.</summary>
+    member val ProgramName = _programName
+
     /// <summary>Force a check of the discriminated union structure.</summary>
     static member CheckStructure() =
         argInfoWithCheck.Value |> ignore


### PR DESCRIPTION
Useful for including program name in other messages and/or as ids in filenames / consumer group names etc