### PR TITLE
fix(ArgumentParser): Correct default programName when run via wrapper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 6.2.2
+* Fix default `programName` when invoking via a wrapper such as `dotnet.exe` [#233](https://github.com/fsprojects/Argu/pull/233)
+
 ### 6.2.1
 * Fix `ParseResults.ProgramName` - make it public (cut and paste error in [#229](https://github.com/fsprojects/Argu/pull/229)) [#231](https://github.com/fsprojects/Argu/pull/231)
 

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -99,7 +99,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     /// <summary>
     ///     Creates a new parser instance based on supplied F# union template.
     /// </summary>
-    /// <param name="programName">Program identifier, e.g. 'cat'. Defaults to the current executable name.</param>
+    /// <param name="programName">Program identifier, e.g. 'cat'. Defaults to the current running executable per <c>Assembly.GetEntryAssembly()</c>.</param>
     /// <param name="helpTextMessage">Message that will be displayed at the top of the help text.</param>
     /// <param name="usageStringCharacterWidth">Text width used when formatting the usage string. Defaults to 80 chars.</param>
     /// <param name="errorHandler">The implementation of IExiter used for error handling. Exception is default.</param>

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -135,7 +135,10 @@ type IDictionary<'K,'V> with
         if ok then Some found
         else None
 
-let currentProgramName = lazy System.Diagnostics.Process.GetCurrentProcess().MainModule.ModuleName
+// NOTE: Prior to 6.2.2, this was System.Diagnostics.Process.GetCurrentProcess()
+//       That previous approach derives `dotnet` when you `dotnet run` a program
+//       (or you invoke via `dotnet tool run` and/or if your IDE wraps the invocation etc)
+let currentProgramName = lazy Assembly.GetEntryAssembly().GetName().Name
 
 /// recognize exprs that strictly contain DU constructors
 /// e.g. <@ Case @> is valid but <@ fun x y -> Case y x @> is invalid


### PR DESCRIPTION
When running via a wrapper such as `dotnet` or `dotnet tool run` (see https://github.com/fsprojects/Argu/pull/232 for more of the full scenario), the default logic derives the `programName` as `dotnet`, i.e. the exit error message becomes:

```
ERROR: unrecognized argument: 'equinox-common-test'.
USAGE: dotnet sync cosmos <snipped>
```

Another common case of this is that VS in ~2019 used to run in a wrapper, so the message would be correct if you Ctrl-F5 run, but not if you F5-run; who knows if that has changed...