### PR TITLE
Extract Argu.Extensions.ConfigurationManager

### DIFF
--- a/Argu.slnx
+++ b/Argu.slnx
@@ -43,4 +43,5 @@
   <Project Path="src/Argu.Extensions.Configuration/Argu.Extensions.Configuration.fsproj" />
   <Project Path="benchmarks/Argu.Benchmarks/Argu.Benchmarks.fsproj" />
   <Project Path="tests/Argu.Tests/Argu.Tests.fsproj" />
+  <Project Path="src/Argu.ConfigurationManager/Argu.ConfigurationManager.fsproj" />
 </Solution>

--- a/src/Argu.ConfigurationManager/Argu.ConfigurationManager.fsproj
+++ b/src/Argu.ConfigurationManager/Argu.ConfigurationManager.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+  </ItemGroup>
+
+  <ItemGroup>
+     <ProjectReference Include="..\Argu\Argu.fsproj" />
+  </ItemGroup>
+	
+</Project>

--- a/src/Argu.ConfigurationManager/Library.fs
+++ b/src/Argu.ConfigurationManager/Library.fs
@@ -1,0 +1,49 @@
+﻿namespace Argu
+
+open System.Configuration
+open System.IO
+
+/// AppSettings XML configuration reader
+type AppSettingsConfigurationReader () =
+    interface IConfigurationReader with
+        member _.Name = "AppSettings configuration reader"
+        member _.GetValue(key : string) = ConfigurationManager.AppSettings[key]
+
+/// AppSettings XML configuration reader
+type AppSettingsConfigurationFileReader private (xmlPath : string, kv : KeyValueConfigurationCollection) =
+    member _.Path = xmlPath
+    interface IConfigurationReader with
+        member _.Name = $"App.config configuration reader: %s{xmlPath}"
+        member _.GetValue(key : string) =
+            match kv[key] with
+            | null -> null
+            | entry -> entry.Value
+
+    /// Create used supplied XML file path
+    static member Create(path : string) =
+        if not <| File.Exists path then raise <| FileNotFoundException(path)
+        let fileMap = ExeConfigurationFileMap(ExeConfigFilename = path)
+        let config = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None)
+        AppSettingsConfigurationFileReader(path, config.AppSettings.Settings)
+
+[<AutoOpen>]
+module ConfigurationReaderExtensions =
+    open System.Reflection
+    open System
+
+    /// Configuration reader implementations
+    type ConfigurationReader with
+
+        /// Create a configuration reader instance using the application's resident AppSettings configuration
+        static member FromAppSettings() : IConfigurationReader = AppSettingsConfigurationReader()
+
+        /// Create a configuration reader instance using a local xml App.Config file
+        static member FromAppSettingsFile(path : string) : IConfigurationReader = AppSettingsConfigurationFileReader.Create path
+
+        /// Create a configuration reader instance using the location of an assembly file
+        static member FromAppSettings(assembly : Assembly) : IConfigurationReader =
+            let path = assembly.Location
+            if String.IsNullOrEmpty path then
+                invalidArg assembly.FullName $"Assembly location for '{assembly.Location}' is null or empty."
+
+            AppSettingsConfigurationFileReader.Create(path + ".config") :> IConfigurationReader

--- a/src/Argu/Argu.fsproj
+++ b/src/Argu/Argu.fsproj
@@ -36,7 +36,6 @@
     <!-- Removal triggers issues in dotnet publish, e.g. for Lambda projects -->
     <!-- Also avoids Rider search finding stuff in FSharp.Core.xml -->
     <PackageReference Include="FSharp.Core" ExcludeAssets="contentfiles" />
-
-    <PackageReference Include="System.Configuration.ConfigurationManager"/>
+    
   </ItemGroup>
 </Project>

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -229,7 +229,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
         let configurationReader =
             match configurationReader with
             | Some c -> c
-            | None -> ConfigurationReader.FromAppSettings()
+            | None -> ConfigurationReader.NullReader
 
         try
             let appSettingsResults = parseKeyValueConfig configurationReader argInfo

--- a/src/Argu/ConfigReaders.fs
+++ b/src/Argu/ConfigReaders.fs
@@ -1,10 +1,7 @@
 ﻿namespace Argu
 
 open System
-open System.Configuration
 open System.Collections.Generic
-open System.IO
-open System.Reflection
 
 /// Abstract key/value configuration reader
 type IConfigurationReader =
@@ -54,29 +51,6 @@ type FunctionConfigurationReader (configFunc : string -> string option, ?name : 
         member _.Name = name
         member _.GetValue(key : string) = configFunc key |> Option.toObj
 
-/// AppSettings XML configuration reader
-type AppSettingsConfigurationReader () =
-    interface IConfigurationReader with
-        member _.Name = "AppSettings configuration reader"
-        member _.GetValue(key : string) = ConfigurationManager.AppSettings[key]
-
-/// AppSettings XML configuration reader
-type AppSettingsConfigurationFileReader private (xmlPath : string, kv : KeyValueConfigurationCollection) =
-    member _.Path = xmlPath
-    interface IConfigurationReader with
-        member _.Name = $"App.config configuration reader: %s{xmlPath}"
-        member _.GetValue(key : string) =
-            match kv[key] with
-            | null -> null
-            | entry -> entry.Value
-
-    /// Create used supplied XML file path
-    static member Create(path : string) =
-        if not <| File.Exists path then raise <| FileNotFoundException(path)
-        let fileMap = ExeConfigurationFileMap(ExeConfigFilename = path)
-        let config = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None)
-        AppSettingsConfigurationFileReader(path, config.AppSettings.Settings)
-
 /// Configuration reader implementations
 [<AbstractClass; Sealed>]
 type ConfigurationReader =
@@ -108,15 +82,3 @@ type ConfigurationReader =
         let read (key : string) = inner.GetValue(prefix + key) |> Option.ofObj
         FunctionConfigurationReader(read, name = $"Environment Variables (prefix=%s{prefix})")
 
-    /// Create a configuration reader instance using the application's resident AppSettings configuration
-    static member FromAppSettings() : IConfigurationReader = AppSettingsConfigurationReader()
-
-    /// Create a configuration reader instance using a local xml App.Config file
-    static member FromAppSettingsFile(path : string) : IConfigurationReader = AppSettingsConfigurationFileReader.Create path
-
-    /// Create a configuration reader instance using the location of an assembly file
-    static member FromAppSettings(assembly : Assembly) : IConfigurationReader =
-        let path = assembly.Location
-        if String.IsNullOrEmpty path then
-            invalidArg assembly.FullName $"Assembly location for '{assembly.Location}' is null or empty."
-        AppSettingsConfigurationFileReader.Create(path + ".config") :> IConfigurationReader

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -14,7 +14,8 @@
     <Compile Include="SeparatorAttributeTests.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>
+    <ProjectReference Include="..\..\src\Argu.ConfigurationManager\Argu.ConfigurationManager.fsproj" />
+    <ProjectReference Include="..\..\src\Argu\Argu.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core"/>


### PR DESCRIPTION
As mentioned in #171, an experiment into moving the System.Configuration.ConfigurationManager code into its own assembly, so the main assembly doesn't have a depdency on ConfigurationManager.

This is just an experiment into moving the code out, but keeping the same API (except with it not trying to read appsettings by default any more) - not an experiment into the best API for splitting things.

So - leaving this here in case the idea is considered interesting for a future major version bump with breaking changes.