### PR TITLE
fix(Mandatory args): list missing cases

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### 6.3.0
 * Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236)
-* Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236)
+* Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 
 ### 6.2.2
 * Fix default `programName` when invoking via a wrapper such as `dotnet.exe` [#233](https://github.com/fsprojects/Argu/pull/233)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 6.3.0
+### 6.2.3
 * Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 * Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### 6.3.0
-* Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236)
+* Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 * Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 
 ### 6.2.2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 6.3.0
+* Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236)
+* Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236)
+
 ### 6.2.2
 * Fix default `programName` when invoking via a wrapper such as `dotnet.exe` [#233](https://github.com/fsprojects/Argu/pull/233)
 

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -79,7 +79,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
     let unrecognized = ResizeArray<string>()
     let unrecognizedParseResults = ResizeArray<obj>()
     let results = lazy(argInfo.Cases.Value |> Array.map (fun _ -> ResizeArray<UnionCaseParseResult>()))
-    let missingMandatoryCasesOfNestedResults = ResizeArray<UnionCaseArgInfo>()
+    let missingMandatoryCasesOfNestedResults = ResizeArray<UnionArgInfo * (UnionCaseArgInfo list)>()
 
     member val IsUsageRequested = false with get,set
 
@@ -135,7 +135,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
           IsUsageRequested = x.IsUsageRequested
           MissingMandatoryCases = [
               yield! missingMandatoryCasesOfNestedResults
-              yield! argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory.Value && results.Value[case.Tag].Count = 0)
+              yield argInfo, (argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory.Value && results.Value[case.Tag].Count = 0) |> Seq.toList)
           ]
         }
 

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -79,7 +79,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
     let unrecognized = ResizeArray<string>()
     let unrecognizedParseResults = ResizeArray<obj>()
     let results = lazy(argInfo.Cases.Value |> Array.map (fun _ -> ResizeArray<UnionCaseParseResult>()))
-    let missingMandatoryCasesOfNestedResults = ResizeArray<UnionArgInfo * (UnionCaseArgInfo list)>()
+    let missingMandatoryCasesOfNestedResults = ResizeArray<UnionArgInfo * UnionCaseArgInfo list>()
 
     member val IsUsageRequested = false with get,set
 

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -135,7 +135,11 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
           IsUsageRequested = x.IsUsageRequested
           MissingMandatoryCases = [
               yield! missingMandatoryCasesOfNestedResults
-              yield argInfo, (argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory.Value && results.Value[case.Tag].Count = 0) |> Seq.toList)
+
+              match argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory.Value && results.Value[case.Tag].Count = 0) |> Seq.toList with
+              | [] -> ()
+              | missingCases ->
+                yield argInfo, missingCases
           ]
         }
 

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -70,8 +70,9 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             | _, ts' -> ts'
 
         match combined, commandLineResults with
-        | _, Some { MissingMandatoryCases = missingCase::_ } when not ignoreMissingMandatory ->
-            error argInfo ErrorCode.PostProcess "missing parameter '%s'." missingCase.Name.Value
+        | _, Some { MissingMandatoryCases = (missingCase::_) as missingCases } when not ignoreMissingMandatory ->
+            let allCasesFormatted = missingCases |> Seq.map (fun c -> c.Name.Value) |> fun v -> System.String.Join("', '", v)
+            error argInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
 
         | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -70,9 +70,9 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             | _, ts' -> ts'
 
         match combined, commandLineResults with
-        | _, Some { MissingMandatoryCases = (missingCase::_) as missingCases } when not ignoreMissingMandatory ->
+        | _, Some { MissingMandatoryCases = (caseArgInfo, (_::_ as missingCases))::_ } when not ignoreMissingMandatory  ->
             let allCasesFormatted = missingCases |> Seq.map (fun c -> c.Name.Value) |> fun v -> System.String.Join("', '", v)
-            error argInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
+            error caseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
 
         | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -70,7 +70,7 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             | _, ts' -> ts'
 
         match combined, commandLineResults with
-        | _, Some { MissingMandatoryCases = (caseArgInfo, (_::_ as missingCases))::_ } when not ignoreMissingMandatory  ->
+        | _, Some { MissingMandatoryCases = (caseArgInfo, missingCases)::_ } when not ignoreMissingMandatory  ->
             let allCasesFormatted = missingCases |> Seq.map (fun c -> c.Name.Value) |> fun v -> System.String.Join("', '", v)
             error caseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
 

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -204,7 +204,7 @@ type UnionParseResults =
         UnrecognizedCliParseResults : obj list
         /// Usage string requested by the caller
         IsUsageRequested : bool
-        MissingMandatoryCases: UnionCaseArgInfo list
+        MissingMandatoryCases: (UnionArgInfo * (UnionCaseArgInfo list)) list
     }
 
 type UnionCaseArgInfo with

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -204,7 +204,7 @@ type UnionParseResults =
         UnrecognizedCliParseResults : obj list
         /// Usage string requested by the caller
         IsUsageRequested : bool
-        MissingMandatoryCases: (UnionArgInfo * (UnionCaseArgInfo list)) list
+        MissingMandatoryCases: (UnionArgInfo * UnionCaseArgInfo list) list
     }
 
 type UnionCaseArgInfo with

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -486,7 +486,7 @@ module ``Argu Tests Main List`` =
     [<Fact>]
     let ``Main command parsing should fail and display all missing mandatories sub command parameters`` () =
         let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
-        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
                                         (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>)
 
     [<Fact>]

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -130,7 +130,7 @@ module ``Argu Tests Main List`` =
         | [<CliPrefix(CliPrefix.None)>] Clean of ParseResults<CleanArgs>
         | [<CliPrefix(CliPrefix.None)>] Required of ParseResults<RequiredSubcommand>
         | [<CliPrefix(CliPrefix.None)>] Unrecognized of ParseResults<GatherUnrecognizedSubcommand>
-        | [<CliPrefix(CliPrefix.None)>] Several_Mandatories of ParseResults<SeveralMandatoriesSubCommand>
+        | [<CliPrefix(CliPrefix.None)>] Multiple_Mandatories of ParseResults<MultipleMandatoriesSubCommand>
         | [<SubCommand; CliPrefix(CliPrefix.None)>] Nullary_Sub
         interface IArgParserTemplate with
             member a.Usage =
@@ -165,7 +165,7 @@ module ``Argu Tests Main List`` =
                 | Clean _ -> "clean state"
                 | Required _ -> "required subcommand"
                 | Unrecognized _ -> "unrecognized subcommand"
-                | Several_Mandatories _ -> "several mandatories subcommand"
+                | Multiple_Mandatories _ -> "multiple mandatories subcommand"
                 | Nullary_Sub -> "nullary subcommand"
                 | List _ -> "variadic params"
                 | Optional _ -> "optional params"
@@ -492,7 +492,7 @@ module ``Argu Tests Main List`` =
 
     [<Fact>]
     let ``Main command parsing should fail and display all missing mandatories sub command parameters`` () =
-        let args = [|"--mandatory-arg" ; "true" ;  "several-mandatories" ; "--valuea"; "5"|]
+        let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
         raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
                                         (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>)
 
@@ -876,7 +876,7 @@ module ``Argu Tests Main List`` =
 
     [<Fact>]
     let ``Required subcommand attribute should fail on missing subcommand2`` () =
-        let args = [|"--mandatory-arg" ; "true" ;  "several-mandatories" ; "--valuea"; "5"|]
+        let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
         raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
                                         (fun e -> <@ e.Message.Contains "valuec" && e.Message.Contains "valuea" @>)
 

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -80,6 +80,20 @@ module ``Argu Tests Main List`` =
         interface IArgParserTemplate with
             member this.Usage = "gus"
 
+    type SeveralMandatoriesSubCommand =
+        | [<Mandatory>] ValueA of int
+        | [<Mandatory>] ValueB of int
+        | [<Mandatory>] ValueC of int
+        | ValueD of int
+        with
+            interface IArgParserTemplate with
+                member this.Usage =
+                    match this with
+                    | ValueA _ -> "Value a"
+                    | ValueB _ -> "Value b"
+                    | ValueC _ -> "Value c"
+                    | ValueD _ -> "Value d"
+
     type Argument =
         | [<AltCommandLine("-v"); Inherit>] Verbose
         | Working_Directory of string
@@ -116,6 +130,7 @@ module ``Argu Tests Main List`` =
         | [<CliPrefix(CliPrefix.None)>] Clean of ParseResults<CleanArgs>
         | [<CliPrefix(CliPrefix.None)>] Required of ParseResults<RequiredSubcommand>
         | [<CliPrefix(CliPrefix.None)>] Unrecognized of ParseResults<GatherUnrecognizedSubcommand>
+        | [<CliPrefix(CliPrefix.None)>] Several_Mandatories of ParseResults<SeveralMandatoriesSubCommand>
         | [<SubCommand; CliPrefix(CliPrefix.None)>] Nullary_Sub
         interface IArgParserTemplate with
             member a.Usage =
@@ -150,6 +165,7 @@ module ``Argu Tests Main List`` =
                 | Clean _ -> "clean state"
                 | Required _ -> "required subcommand"
                 | Unrecognized _ -> "unrecognized subcommand"
+                | Several_Mandatories _ -> "several mandatories subcommand"
                 | Nullary_Sub -> "nullary subcommand"
                 | List _ -> "variadic params"
                 | Optional _ -> "optional params"
@@ -661,7 +677,7 @@ module ``Argu Tests Main List`` =
     [<Fact>]
     let ``Get all subcommand parsers`` () =
         let subcommands = parser.GetSubCommandParsers()
-        test <@ subcommands.Length = 6 @>
+        test <@ subcommands.Length = 7 @>
         test <@ subcommands |> List.forall (fun sc -> sc.IsSubCommandParser) @>
 
     [<Fact>]

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -875,10 +875,10 @@ module ``Argu Tests Main List`` =
         test <@ results.IsUsageRequested @>
 
     [<Fact>]
-    let ``Required subcommand attribute should fail on missing subcommand2`` () =
+    let ``Required subcommand attribute should fail on missing subcommand and display usage of subcommand and not main command`` () =
         let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
-        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
-                                        (fun e -> <@ e.Message.Contains "valuec" && e.Message.Contains "valuea" @>)
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args) @>
+                                        (fun e -> <@ e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>)
 
     [<HelpFlags("--my-help")>]
     [<HelpDescription("waka jawaka")>]

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -85,14 +85,7 @@ module ``Argu Tests Main List`` =
         | [<Mandatory>] ValueB of int
         | [<Mandatory>] ValueC of int
         | ValueD of int
-        with
-            interface IArgParserTemplate with
-                member this.Usage =
-                    match this with
-                    | ValueA _ -> "Value a"
-                    | ValueB _ -> "Value b"
-                    | ValueC _ -> "Value c"
-                    | ValueD _ -> "Value d"
+        interface IArgParserTemplate with member this.Usage = "multiple mandatories subcommand arg"
 
     type Argument =
         | [<AltCommandLine("-v"); Inherit>] Verbose

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -870,7 +870,7 @@ module ``Argu Tests Main List`` =
     [<Fact>]
     let ``Required subcommand attribute should fail on missing subcommand and display usage of subcommand and not main command`` () =
         let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
-        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args) @>
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
                                         (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'"
                                                       && e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>)
 

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -871,7 +871,8 @@ module ``Argu Tests Main List`` =
     let ``Required subcommand attribute should fail on missing subcommand and display usage of subcommand and not main command`` () =
         let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
         raisesWith<ArguParseException> <@ parser.ParseCommandLine(args) @>
-                                        (fun e -> <@ e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>)
+                                        (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'"
+                                                      && e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>)
 
     [<HelpFlags("--my-help")>]
     [<HelpDescription("waka jawaka")>]

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -874,6 +874,11 @@ module ``Argu Tests Main List`` =
         let results = parser.ParseCommandLine (args, raiseOnUsage = false)
         test <@ results.IsUsageRequested @>
 
+    [<Fact>]
+    let ``Required subcommand attribute should fail on missing subcommand2`` () =
+        let args = [|"--mandatory-arg" ; "true" ;  "several-mandatories" ; "--valuea"; "5"|]
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
+                                        (fun e -> <@ e.Message.Contains "valuec" && e.Message.Contains "valuea" @>)
 
     [<HelpFlags("--my-help")>]
     [<HelpDescription("waka jawaka")>]

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -80,7 +80,7 @@ module ``Argu Tests Main List`` =
         interface IArgParserTemplate with
             member this.Usage = "gus"
 
-    type SeveralMandatoriesSubCommand =
+    type MultipleMandatoriesSubCommand =
         | [<Mandatory>] ValueA of int
         | [<Mandatory>] ValueB of int
         | [<Mandatory>] ValueC of int

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -491,6 +491,12 @@ module ``Argu Tests Main List`` =
                                     (fun e -> <@ e.FirstLine.Contains "--branch" @>)
 
     [<Fact>]
+    let ``Main command parsing should fail and display all missing mandatories sub command parameters`` () =
+        let args = [|"--mandatory-arg" ; "true" ;  "several-mandatories" ; "--valuea"; "5"|]
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, raiseOnUsage = true) @>
+                                        (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>)
+
+    [<Fact>]
     let ``Main command parsing should not fail on missing mandatory sub command parameter if ignoreMissing`` () =
         let args = [|"--mandatory-arg" ; "true" ; "checkout"  |]
         let results = parser.ParseCommandLine(args, ignoreMissing = true)

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -868,7 +868,7 @@ module ``Argu Tests Main List`` =
         test <@ results.IsUsageRequested @>
 
     [<Fact>]
-    let ``Required subcommand attribute should fail on missing subcommand and display usage of subcommand and not main command`` () =
+    let ``Should fail if mandatory case is missing on a subcommand and display usage of subcommand and not main command`` () =
         let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
         raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
                                         (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'"


### PR DESCRIPTION
A regression has occurred in https://github.com/fsprojects/Argu/pull/127

Previously, if a case was missing, help was displayed for the subcommand and not for the main command. This was the same behaviour as when there was an unknown case.
This PR corrects this to restore the old behaviour.

At the same time, the error message when a case is missing has been improved. It used to display only the first missing case.
Now it displays all the missing cases.
