### PR TITLE
fixes #242: add missing attribute targets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 6.2.4
+* Add `AttributeUsage` targets for methods which will be required in .NET 8.0.300 [#243](https://github.com/fsprojects/Argu/pull/243) [@dlidstrom](https://github.com/dlidstrom)
+
 ### 6.2.3
 * Improve error message on missing cases on a subcommands (display all missing cases) [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
 * Fix the regression of the [#127](https://github.com/fsprojects/Argu/pull/127) merged in 6.1.2 and fix usage display when there are missing case in subcommands. [#236](https://github.com/fsprojects/Argu/pull/236) [@fpellet](https://github.com/fpellet)
@@ -24,7 +27,7 @@
 * Use [`Dotnet.ReproducibleBuilds`](https://github.com/dotnet/reproducible-builds) [#174](https://github.com/fsprojects/Argu/pull/174)
 
 ### 6.1.2
-* Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116) [@chestercodes](https://github.com/chestercodes) 
+* Fix Mandatory arguments in nested subcommands. [#116](https://github.com/fsprojects/Argu/issues/116) [@chestercodes](https://github.com/chestercodes)
 * Fix Consistent handling of numeric decimal separators using invariant culture. [#159](https://github.com/fsprojects/Argu/issues/159) [@stmax82](https://github.com/stmax82)
 
 ### 6.1.1
@@ -194,5 +197,5 @@
 * Fix packaging issue.
 
 #### 0.5.8
-* Include optional BindingFlags parameter. 
+* Include optional BindingFlags parameter.
 * Include support for all primitive types.

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -6,38 +6,38 @@ open System
 
 /// Parse multiple parameters in AppSettings as comma separated values. OBSOLETE
 [<Obsolete("Please use list parameters instead.")>]
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type ParseCSVAttribute () = inherit Attribute ()
 
 /// Consume all remaining CLI tokens using this parameter wherever it might occur. OBSOLETE
 [<Obsolete("Please use list parameters instead.")>]
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type RestAttribute () = inherit Attribute ()
 
 /// Hides argument from command line argument usage string.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type HiddenAttribute () = inherit Attribute ()
 
 /// Demands at least one parsed result for this argument; a parse exception is raised otherwise.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type MandatoryAttribute () = inherit Attribute ()
 
 /// Demands that the argument should be specified at most once; a parse exception is raised otherwise.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type UniqueAttribute () = inherit Attribute ()
 
 /// Demands that the argument should be specified exactly once; a parse exception is raised otherwise.
 /// Equivalent to attaching both the Mandatory and Unique attribute on the parameter.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type ExactlyOnceAttribute () = inherit Attribute ()
 
 /// Denotes that the given argument should be inherited in the scope of any subcommands.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type InheritAttribute() = inherit Attribute()
 
 /// Denotes that the given argument should accumulate any unrecognized arguments it encounters.
 /// Must contain a single field of type string
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type GatherUnrecognizedAttribute() = inherit Attribute()
 
 /// Demands that at least one subcommand is specified in the CLI; a parse exception is raised otherwise.
@@ -46,20 +46,20 @@ type RequireSubcommandAttribute () = inherit Attribute()
 
 /// Requires that CLI parameters should not override AppSettings parameters.
 /// Will return parsed results from both AppSettings and CLI.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type GatherAllSourcesAttribute () = inherit Attribute ()
 
 /// Disable CLI parsing for this argument. Use for AppSettings parsing only.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type NoCommandLineAttribute () = inherit Attribute ()
 
 /// Disable AppSettings parsing for this branch. Use for CLI parsing only.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type NoAppSettingsAttribute () = inherit Attribute ()
 
 /// Specifies a custom set of Help/Usage switches for the CLI.
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
-type HelpFlagsAttribute ([<ParamArray>] names : string []) = 
+type HelpFlagsAttribute ([<ParamArray>] names : string []) =
     inherit Attribute()
     member _.Names = names
 
@@ -74,38 +74,38 @@ type HelpDescriptionAttribute (description : string) =
     member _.Description = description
 
 /// Declares that argument should be placed at specific position.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CliPositionAttribute(position : CliPosition) =
     inherit Attribute()
     member _.Position = position
 
 /// Declares that argument can only be placed at the beginning of the CLI syntax.
 /// A parse exception will be raised if that is not the case.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type FirstAttribute () = inherit CliPositionAttribute (CliPosition.First)
 
 /// Declares that argument can only be placed at the end of the CLI syntax.
 /// A parse exception will be raised if that is not the case.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type LastAttribute () = inherit CliPositionAttribute (CliPosition.Last)
 
 /// Declares that argument is a subcommand.
 /// A parse exception will be raised if the argument has parameters
 /// and their type is not ParseResults<_>.
 /// Implicit if the argument does have a parameter of type ParseResults<_>.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type SubCommandAttribute () = inherit Attribute()
 
 /// Declares that argument is the main command of the CLI syntax.
 /// Arguments are specified without requiring a switch.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type MainCommandAttribute (argumentName : string) = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type MainCommandAttribute (argumentName : string) =
     inherit Attribute()
     new () = MainCommandAttribute(null)
     member _.ArgumentName = argumentName
 
 /// Print F# 3.1 field labels in usage string. OBSOLETE
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 [<Obsolete("Argu 3.0 prints union labels by default. Please remove this attribute.")>]
 type PrintLabelsAttribute () = inherit Attribute ()
 
@@ -113,29 +113,29 @@ type PrintLabelsAttribute () = inherit Attribute ()
 /// e.g. '--param<separator>arg' or '--param key<separator>value'.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 /// Can be used to specify any assignment separator.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type CustomAssignmentAttribute (separator : string) = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type CustomAssignmentAttribute (separator : string) =
     inherit Attribute ()
     member _.Separator = separator
 
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type EqualsAssignmentAttribute () = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type EqualsAssignmentAttribute () =
     inherit CustomAssignmentAttribute("=")
 
 /// Use '--param:arg' or '--param key:value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type ColonAssignmentAttribute () = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type ColonAssignmentAttribute () =
     inherit CustomAssignmentAttribute(":")
-    
+
 /// Use a custom separator for parameter assignment.
 /// e.g. '--param<separator>arg'
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
 /// Can be used to specify any assignment separator.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAssignmentOrSpacedAttribute (separator : string) =
     inherit Attribute ()
     member _.Separator = separator
@@ -143,20 +143,20 @@ type CustomAssignmentOrSpacedAttribute (separator : string) =
 /// Use '--param=arg' assignment syntax in CLI.
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type EqualsAssignmentOrSpacedAttribute () = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type EqualsAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute("=")
 
 /// Use '--param:arg' assignment syntax in CLI.
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
-type ColonAssignmentOrSpacedAttribute () = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type ColonAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute(":")
 
 /// Declares a custom default CLI identifier for the current parameter.
 /// Replaces the auto-generated identifier name.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string []) =
     inherit Attribute ()
     member _.Name = name
@@ -165,21 +165,21 @@ type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string 
 /// Declares a set of secondary CLI identifiers for the current parameter.
 /// Does not replace the default identifier which is either auto-generated
 /// or specified by the CustomCommandLine attribute.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
-type AltCommandLineAttribute ([<ParamArray>] names : string []) = 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = true)>]
+type AltCommandLineAttribute ([<ParamArray>] names : string []) =
     inherit Attribute ()
     member _.Names = names
 
 /// Declares a custom key identifier for the current parameter in AppSettings parsing.
 /// Replaces the auto-generated identifier name.
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAppSettingsAttribute (name : string) =
     inherit Attribute ()
     member _.Name = name
 
 /// Specify a custom value separator in AppSettings parsing parameters.
 /// Used in CSV or list-based parameter parsing.
-[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], splitOptions : StringSplitOptions) =
     inherit Attribute()
     new (separator : char) = AppSettingsSeparatorAttribute([|string separator|], StringSplitOptions.None)
@@ -188,7 +188,7 @@ type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], split
 
 /// Specifies a custom prefix for auto-generated CLI names.
 /// This defaults to double dash ('--').
-[<AttributeUsage(AttributeTargets.Property ||| AttributeTargets.Class, AllowMultiple = false)>]
-type CliPrefixAttribute(prefix : string) = 
-    inherit Attribute() 
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Class, AllowMultiple = false)>]
+type CliPrefixAttribute(prefix : string) =
+    inherit Attribute()
     member _.Prefix = prefix


### PR DESCRIPTION
I've added `AttributeTargets.Method` to all attributes which have `AttributeTargets.Property`. I also added to obsolete attributes thinking it is necessary to avoid forcing removal of those attributes.