### PR TITLE
chore(Deps): Drop Min FSharp.Core to 6.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25"/>
 
     <!-- Impl deps -->
-    <PackageVersion Include="FSharp.Core" Version="6.0.7"/>
+    <PackageVersion Include="FSharp.Core" Version="6.0.0"/>
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.4.0"/>
 
     <!-- Test deps -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
     <PackageVersion Include="xunit" Version="2.9.2"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7"/>
-    <PackageVersion Include="Unquote" Version="6.1.0"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    <PackageVersion Include="Unquote" Version="7.0.1"/>
   </ItemGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 6.2.5
+* Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/SwensenSoftware/unquote/pull/264)
+* target Unquote 7.0.1 now that it has [reduced `FSharp.Core` dependencies](https://github.com/SwensenSoftware/unquote/pull/172) [#264](https://github.com/SwensenSoftware/unquote/pull/264)
+  
 ### 6.2.4
 * Add `AttributeUsage` targets for methods which will be required in .NET 8.0.300 [#243](https://github.com/fsprojects/Argu/pull/243) [@dlidstrom](https://github.com/dlidstrom)
 

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" VersionOverride="6.0.7"/>
+    <PackageReference Include="FSharp.Core"/>
 
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="Unquote"/>


### PR DESCRIPTION
And bump test deps

Lost the will to live investigating how the FSharp.Core dependency got up to 6.0.7 thanks to all the depandabot spam; hopefully we can keep it stable at this - IMO libraries should depend on the minimum non vulnerable version of dependencies

related: https://github.com/SwensenSoftware/unquote/pull/172