### PR TITLE
GitHubActions: don't restrict CI to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,7 @@ name: Build & Tests
 env:
   DOTNET_NOLOGO: true
 
-on:
-  workflow_dispatch:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Build:


### PR DESCRIPTION
There's no point about restricting CI to master branch; doing this will prevent contributors to know the CI status (e.g. the result from running unit tests after their proposed contributions) before they propose a PullRequest; because normally people create branches when they want to start to work on something (instead of having to use the master branch of their fork).