### PR TITLE
refactor: Narrow #nowarn 44 scope to obsolete-attribute helpers

### DIFF
--- a/src/Argu/Argu.fsproj
+++ b/src/Argu/Argu.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="Types.fs"/>
     <Compile Include="Attributes.fs"/>
+    <Compile Include="ObsoleteHelpers.fs"/>
     <Compile Include="Utils.fs"/>
     <Compile Include="ConfigReaders.fs"/>
     <Compile Include="UnionArgInfo.fs"/>

--- a/src/Argu/ObsoleteHelpers.fs
+++ b/src/Argu/ObsoleteHelpers.fs
@@ -1,0 +1,8 @@
+#nowarn "44" // ParseCSV and Rest attributes are intentionally [<Obsolete>]; we still parse them for backwards compatibility
+module internal Argu.ObsoleteHelpers
+
+let hasParseCsvAttribute (attributes: obj[]) =
+    attributes |> Array.exists (fun x -> x :? ParseCSVAttribute)
+
+let hasRestAttribute (attributes: obj[]) =
+    attributes |> Array.exists (fun x -> x :? RestAttribute)

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -1,8 +1,6 @@
 ﻿[<AutoOpen>]
 module internal Argu.PreCompute
 
-#nowarn "44"
-
 open System
 open System.Reflection
 open System.Text.RegularExpressions
@@ -300,13 +298,13 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let declaringTypeAttributes = lazy uci.DeclaringType.GetCustomAttributes(true)
 
     let isNoCommandLine = lazy(hasAttribute2<NoCommandLineAttribute> attributes.Value declaringTypeAttributes.Value)
-    let isAppSettingsCSV = lazy(hasAttribute<ParseCSVAttribute> attributes.Value)
+    let isAppSettingsCSV = lazy(ObsoleteHelpers.hasParseCsvAttribute attributes.Value)
     let isExactlyOnce = lazy(hasAttribute2<ExactlyOnceAttribute> attributes.Value declaringTypeAttributes.Value)
     let isMandatory = lazy(isExactlyOnce.Value || hasAttribute2<MandatoryAttribute> attributes.Value declaringTypeAttributes.Value)
     let isUnique = lazy(isExactlyOnce.Value || hasAttribute2<UniqueAttribute> attributes.Value declaringTypeAttributes.Value)
     let isInherited = lazy(hasAttribute<InheritAttribute> attributes.Value)
     let isGatherAll = lazy(hasAttribute<GatherAllSourcesAttribute> attributes.Value)
-    let isRest = lazy(hasAttribute<RestAttribute> attributes.Value)
+    let isRest = lazy(ObsoleteHelpers.hasRestAttribute attributes.Value)
     let isHidden = lazy(hasAttribute<HiddenAttribute> attributes.Value)
     let isExplicitSubCommand = lazy(hasAttribute<SubCommandAttribute> attributes.Value)
 


### PR DESCRIPTION
## Summary

- Move the two obsolete-attribute lookups in `PreCompute.fs` (for `ParseCSVAttribute` and `RestAttribute`) into a new `src/Argu/ObsoleteHelpers.fs` module that carries its own `#nowarn "44"`.
- Remove the file-level `#nowarn "44"` from `PreCompute.fs`.

## Why

`#nowarn "44"` at the top of `PreCompute.fs` (~700 LOC) was suppressing all obsolete-API warnings file-wide just to allow two attribute-type references. Anything else that became obsolete would slip through silently. Scoping the suppression to a 9-line helper file restores the warning everywhere else.

## Test plan

- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 112/112 pass