### PR TITLE
refactor: Remove reimplemented stdlib helpers from Utils.fs

### DIFF
--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -19,7 +19,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
     // restriction predicate based on optional parse source
     let restrictF flags : UnionCaseParseResult -> bool =
         let flags = defaultArg flags ParseSource.All
-        fun x -> Enum.hasFlag flags x.Source
+        fun x -> flags.HasFlag(x.Source)
 
     let getResults rs (e : Expr) = results.Cases[expr2Uci(e).Tag] |> Seq.filter (restrictF rs)
     let containsResult rs (e : Expr) = e |> getResults rs |> Seq.isEmpty |> not

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -23,50 +23,9 @@ let getEnvironmentCommandLineArgs () =
     | args -> args[1..]
 
 [<RequireQualifiedAccess>]
-module Enum =
-
-    let inline hasFlag (flag : ^Enum) (value : ^Enum) = flag &&& value = value
-
-[<RequireQualifiedAccess>]
-module Array =
-
-    let last (ts : 'T[]) =
-        match ts.Length with
-        | 0 -> invalidArg "xs" "input array is empty."
-        | n -> ts[n - 1]
-
-    let tryLast (ts : 'T[]) =
-        match ts.Length with
-        | 0 -> None
-        | n -> Some ts[n-1]
-
-[<RequireQualifiedAccess>]
-module List =
-
-    /// try fetching last element of a list
-    let rec tryLast xs =
-        match xs with
-        | [] -> None
-        | [x] -> Some x
-        | _ :: rest -> tryLast rest
-
-[<RequireQualifiedAccess>]
 module Seq =
 
-    /// try fetching first element of a sequence
-    let tryFirst (xs : seq<'T>) =
-        let en = xs.GetEnumerator()
-        if en.MoveNext() then Some en.Current
-        else None
-
-    /// try fetching last element of a sequence
-    let tryLast (xs : seq<'T>) =
-        let mutable isAccessed = false
-        let mutable current = Unchecked.defaultof<'T>
-        for x in xs do isAccessed <- true; current <- x
-        if isAccessed then Some current else None
-
-    /// partition sequence according to predicate
+    /// partition sequence according to predicate; materialises both branches into arrays
     let partition (predicate : 'T -> bool) (ts : seq<'T>) =
         let l,r = new ResizeArray<'T>(), new ResizeArray<'T>()
         for t in ts do
@@ -198,7 +157,7 @@ let escapeCliString (value : string) =
                             * 2N+1 backslashes + " ==> N backslashes + literal "
                             * N backslashes ==> N backslashes
                         *)
-                        let nextCharAfterBackslashes = value |> Seq.skip (i + 1) |> Seq.filter (fun c -> c <> '\\') |> Seq.tryFirst
+                        let nextCharAfterBackslashes = value |> Seq.skip (i + 1) |> Seq.filter (fun c -> c <> '\\') |> Seq.tryHead
                         if nextCharAfterBackslashes = Some '"' || nextCharAfterBackslashes = None then
                             yield '\\'
                             yield '\\'


### PR DESCRIPTION
## Summary

- Delete locally-defined `Array.last`, `Array.tryLast`, `List.tryLast`, `Seq.tryFirst`, `Seq.tryLast`, `Enum.hasFlag` modules from `Utils.fs`.
- Switch one internal `Seq.tryFirst` call in `escapeCliString` to `Seq.tryHead`.
- Switch `Enum.hasFlag flags x.Source` in `ParseResults.fs` to `flags.HasFlag(x.Source)`.

## Why

These helpers have shipped in `FSharp.Core` since F# 4.5 (which is well below the current minimum). Keeping local duplicates is dead weight. `Seq.partition` is kept because the local version materialises into arrays rather than seqs and is used as such.

## Test plan

- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 112/112 pass