### PR TITLE
docs: Document last-wins attribute pickup in TryGetAttribute

### DIFF
--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -124,6 +124,12 @@ type MemberInfo with
     member m.ContainsAttribute<'T when 'T :> Attribute> () : bool=
         m.GetCustomAttributes(typeof<'T>, true) |> Seq.isEmpty |> not
 
+    /// Returns the matching attribute of type 'T, or None.
+    /// When the member has multiple matching attributes (including any inherited
+    /// from declaring types), the *last* attribute in reflection order is returned.
+    /// Callers relying on inherited declaring-type attributes via `hasAttribute2`
+    /// should be aware that an attribute on the case can be overridden by a later
+    /// attribute on the same case, not by an attribute on the declaring type.
     member m.TryGetAttribute<'T when 'T :> Attribute> () : 'T option =
         match m.GetCustomAttributes(typeof<'T>, true) |> Seq.toArray with
         | [||] -> None


### PR DESCRIPTION
## Summary

Add an XML doc-comment to `MemberInfo.TryGetAttribute<'T>` (Utils.fs) noting that when multiple matching attributes are present, the *last* one (per `Array.last`) is returned.

## Why

The convention in most reflection helpers is first-match. Argu picks last-match silently, and `hasAttribute2` in `PreCompute.fs` then falls back to declaring-type attributes after that. Documenting the rule so callers don't have to read the implementation to discover it.

## Test plan

- [x] `dotnet build -c Release` — clean
- Docs-only change; no behaviour change.