### PR TITLE
fix: Include the offending expression in expr2Uci's error message

### DIFF
--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -148,14 +148,18 @@ let expr2Uci (e : Expr) =
         if vars.Length = exprs.Length then Some vars
         else None
 
-    let rec aux (tupledArg : Var option) vars (e : Expr) =
-        match tupledArg, e with
+    let rec aux (tupledArg : Var option) vars (e' : Expr) =
+        match tupledArg, e' with
         | None, Lambda(arg, b) -> aux (Some arg) vars b
         | Some arg, Let(x, TupleGet(Var varg, _), b) when arg = varg -> aux tupledArg (x :: vars) b
         | None, NewUnionCase(u, []) -> u
         | Some a, NewUnionCase(u, [Var x]) when a = x -> u
         | Some _, NewUnionCase(u, Vars args) when vars.Length > 0 && List.rev vars = args -> u
-        | _ -> invalidArg "expr" "Only union constructors are permitted in expression based queries."
+        | _ ->
+            let rendered =
+                let s = sprintf "%A" e
+                if s.Length > 200 then s.Substring(0, 200) + "…" else s
+            invalidArg "expr" (sprintf "Only union constructors are permitted in expression based queries. Got: %s" rendered)
 
     aux None [] e
 


### PR DESCRIPTION
## Summary

`Utils.expr2Uci` raises `invalidArg "expr" "Only union constructors are permitted in expression based queries."` without naming the expression. Thread the original expression through `sprintf "%A"`, cap at 200 chars, and include it in the message.

## Why

Callers using the quoted-DU API (`GetSubCommandParser`, `GetResult`, etc.) can hit this if they pass anything more complex than a bare constructor. Without the expression in the message they have to bisect their call sites to find the offender.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 112/112 pass