### PR TITLE
docs: Document order-sensitive equality on ParseResults

### DIFF
--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -3,6 +3,16 @@
 open FSharp.Quotations
 
 /// Argument parsing result holder.
+///
+/// <remarks>
+/// Equality, hashing and comparison are computed over the in-order sequence of
+/// parsed cases (as returned by <c>GetAllResults()</c>). Two <c>ParseResults</c>
+/// containing the same arguments in a different order will <em>not</em> compare
+/// equal. The <c>EqualityConditionalOn</c>/<c>ComparisonConditionalOn</c>
+/// attributes on the <c>'Template</c> parameter only control whether the
+/// corresponding F# type-class constraint flows through; they do not change
+/// the order-sensitive semantics implemented here.
+/// </remarks>
 [<Sealed; AutoSerializable(false); StructuredFormatDisplay("{StructuredFormatDisplay}")>]
 type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template when 'Template :> IArgParserTemplate>
     internal (argInfo : UnionArgInfo, results : UnionParseResults, programName : string, description : string option, usageStringCharWidth : int, exiter : IExiter) =


### PR DESCRIPTION
## Summary

Add a `<remarks>` block to `ParseResults<'Template>` explaining that `Equals`, `GetHashCode` and `IComparable.CompareTo` are computed over the in-order sequence of parsed cases. Two parses containing the same arguments in a different order do not compare equal.

## Why

The `[<EqualityConditionalOn>]`/`[<ComparisonConditionalOn>]` attributes on the type parameter look like they describe the comparison semantics, but they only control type-class constraint flow. The actual equality is `Unchecked.equals` over the parsed-case sequence — order-sensitive and undocumented.

## Test plan

- [x] `dotnet build -c Release` — clean
- Docs-only change; no behaviour change.