### PR TITLE
fix: Report all missing-mandatory groups in a single error message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### 6.2.6
 * Fix NRE in derivation of programName introduced in 6.2.2 [#292](https://github.com/SwensenSoftware/unquote/pull/292) [@dimension-zero](https://github.com/dimension-zero)
 * Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
+* Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
 * Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/SwensenSoftware/unquote/pull/264)

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -70,9 +70,16 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             | _, ts' -> ts'
 
         match combined, commandLineResults with
-        | _, Some { MissingMandatoryCases = (caseArgInfo, missingCases)::_ } when not ignoreMissingMandatory  ->
-            let allCasesFormatted = missingCases |> Seq.map (fun c -> c.Name.Value) |> fun v -> System.String.Join("', '", v)
-            error caseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
+        | _, Some { MissingMandatoryCases = (firstCaseArgInfo, _) :: _ as allGroups } when not ignoreMissingMandatory  ->
+            // Walk every group across the parsed tree so the user sees all missing
+            // parameters in one error, not just the first group's. Saves a round trip
+            // when both the top level and a subcommand have unmet mandatories.
+            let allMissingNames =
+                allGroups
+                |> Seq.collect (fun (_, missingCases) -> missingCases |> Seq.map (fun c -> c.Name.Value))
+                |> Seq.toArray
+            let allCasesFormatted = System.String.Join("', '", allMissingNames)
+            error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
 
         | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -71,13 +71,11 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
 
         match combined, commandLineResults with
         | _, Some { MissingMandatoryCases = (firstCaseArgInfo, _) :: _ as allGroups } when not ignoreMissingMandatory  ->
-            // Note we walk every group across the parsed tree so the user learns all missing params in one error
-            // (as opposed to having to fix level by level with multiple runs)
-            let allMissingNames = seq {
-                for _, missingCases in allGroups do
-                    for c in missingCases -> c.Name.Value }
-            let casesFormatted = String.concat "', '" allMissingNames
-            error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." casesFormatted
+            // NOTE also need to convey missing child / trailing args, not just flag first problem
+            let allMissingParamNames =
+                seq { for _, missing in allGroups do for m in missing -> m.Name.Value }
+                |> String.concat "', '"
+            error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allMissingParamNames
 
         | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -71,15 +71,13 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
 
         match combined, commandLineResults with
         | _, Some { MissingMandatoryCases = (firstCaseArgInfo, _) :: _ as allGroups } when not ignoreMissingMandatory  ->
-            // Walk every group across the parsed tree so the user sees all missing
-            // parameters in one error, not just the first group's. Saves a round trip
-            // when both the top level and a subcommand have unmet mandatories.
-            let allMissingNames =
-                allGroups
-                |> Seq.collect (fun (_, missingCases) -> missingCases |> Seq.map (fun c -> c.Name.Value))
-                |> Seq.toArray
-            let allCasesFormatted = System.String.Join("', '", allMissingNames)
-            error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allCasesFormatted
+            // Note we walk every group across the parsed tree so the user learns all missing params in one error
+            // (as opposed to having to fix level by level with multiple runs)
+            let allMissingNames = seq {
+                for _, missingCases in allGroups do
+                    for c in missingCases -> c.Name.Value }
+            let casesFormatted = String.concat "', '" allMissingNames
+            error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." casesFormatted
 
         | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -490,6 +490,16 @@ module ``Argu Tests Main List`` =
                                         (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>)
 
     [<Fact>]
+    let ``Missing mandatories at parent and subcommand levels are reported together`` () =
+        // Subcommand mandatories are missing; the parent's --mandatory-arg is also missing.
+        // The error must surface all four names in a single message, not just one group.
+        let args = [|"multiple-mandatories" ; "--valuea"; "5"|]
+        raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
+                                        (fun e -> <@ e.FirstLine.Contains "--valueb"
+                                                    && e.FirstLine.Contains "--valuec"
+                                                    && e.FirstLine.Contains "--mandatory-arg" @>)
+
+    [<Fact>]
     let ``Main command parsing should not fail on missing mandatory sub command parameter if ignoreMissing`` () =
         let args = [|"--mandatory-arg" ; "true" ; "checkout"  |]
         let results = parser.ParseCommandLine(args, ignoreMissing = true)


### PR DESCRIPTION
## Summary

When mandatory parameters are missing at multiple nesting levels (e.g., a top-level mandatory and a subcommand's mandatory), the user previously saw only the first group's names. Walk every group in `MissingMandatoryCases` and concatenate all names into one message.

Adds one regression test (`Missing mandatories at parent and subcommand levels are reported together`).

## Why

A round trip per missing-parameter group is friction the user doesn't have to pay — we already have the information by the time we raise the error.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 113/113 pass (was 112, +1 new test)
- Existing tests still pass: they used `Contains` checks rather than exact-match, so additional names appended to the list are tolerated.