### PR TITLE
samples: Add Argu.Samples.Introspect demonstrating the introspection API

### DIFF
--- a/Argu.slnx
+++ b/Argu.slnx
@@ -39,6 +39,7 @@
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/Argu.Samples.LS/Argu.Samples.LS.fsproj" />
+    <Project Path="samples/Argu.Samples.Introspect/Argu.Samples.Introspect.fsproj" />
   </Folder>
   <Project Path="src/Argu/Argu.fsproj" />
   <Project Path="tests/Argu.Tests/Argu.Tests.fsproj" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 ### 6.2.6
 * Fix NRE in derivation of programName introduced in 6.2.2 [#292](https://github.com/SwensenSoftware/unquote/pull/292) [@dimension-zero](https://github.com/dimension-zero)
-* Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
-* Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
+* Add `Argu.Samples.Introspect` sample [#298](https://github.com/SwensenSoftware/unquote/pull/298) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
 * Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/SwensenSoftware/unquote/pull/264)

--- a/samples/Argu.Samples.Introspect/Argu.Samples.Introspect.fsproj
+++ b/samples/Argu.Samples.Introspect/Argu.Samples.Introspect.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>argu-introspect</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Arguments.fs"/>
+    <Compile Include="Program.fs"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>
+  </ItemGroup>
+</Project>

--- a/samples/Argu.Samples.Introspect/Argu.Samples.Introspect.fsproj
+++ b/samples/Argu.Samples.Introspect/Argu.Samples.Introspect.fsproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>argu-introspect</AssemblyName>
+    <!-- NOTE required as EXEs by default are treated as packable by the FAKE Release fsx   -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/Argu.Samples.Introspect/Arguments.fs
+++ b/samples/Argu.Samples.Introspect/Arguments.fs
@@ -1,0 +1,32 @@
+module Argu.Samples.Introspect.Arguments
+
+open Argu
+
+type CommitArgs =
+    | [<Mandatory>] Message of string
+    | [<AltCommandLine("-a")>] All
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Message _ -> "commit message"
+            | All -> "stage tracked files before committing"
+
+type PushArgs =
+    | [<AltCommandLine("-f")>] Force
+    | Remote of string
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Force -> "force-push the branch"
+            | Remote _ -> "remote name (default: origin)"
+
+type GitArgs =
+    | [<AltCommandLine("-v"); Inherit>] Verbose
+    | [<CliPrefix(CliPrefix.None)>] Commit of ParseResults<CommitArgs>
+    | [<CliPrefix(CliPrefix.None)>] Push of ParseResults<PushArgs>
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Verbose -> "verbose output"
+            | Commit _ -> "record a snapshot of the working tree"
+            | Push _ -> "send local commits to a remote"

--- a/samples/Argu.Samples.Introspect/Program.fs
+++ b/samples/Argu.Samples.Introspect/Program.fs
@@ -1,0 +1,46 @@
+module Argu.Samples.Introspect.Main
+
+// Demonstrates Argu's introspection API:
+//   1. ArgumentParser.GetArgumentCases() returns ArgumentCaseInfo records
+//      describing every case in the union template.
+//   2. ArgumentParser.GetSubCommandParsers() returns untyped ArgumentParser
+//      instances for every case whose payload is a ParseResults<_>.
+//   3. IArgumentParserVisitor<'R> recovers the typed parser from the
+//      untyped base, allowing rank-2 generic code over an unknown template.
+
+open Argu
+open Argu.Samples.Introspect.Arguments
+
+// A visitor that just returns the parser's typed program name; useful
+// to show how the visitor pattern bridges untyped → typed.
+let typedProgramName (parser : ArgumentParser) =
+    parser.Accept
+        { new IArgumentParserVisitor<string> with
+            member _.Visit<'T when 'T :> IArgParserTemplate> (typed : ArgumentParser<'T>) =
+                typeof<'T>.Name }
+
+// Walk a parser's schema, printing case metadata and recursing into subcommand parsers.
+let rec dump (depth : int) (parser : ArgumentParser) =
+    let indent = String.replicate depth "  "
+    printfn "%sParser: %s (subcommand=%b)" indent (typedProgramName parser) parser.IsSubCommandParser
+    for case in parser.GetArgumentCases() do
+        let cliNames = case.CommandLineNames.Value |> String.concat ", "
+        printfn "%s  - %s [%O] cli=[%s] mandatory=%b hidden=%b"
+                indent
+                case.Name.Value
+                case.ArgumentType
+                cliNames
+                case.IsMandatory.Value
+                case.IsHidden.Value
+    for sub in parser.GetSubCommandParsers() do
+        dump (depth + 1) sub
+
+[<EntryPoint>]
+let main _argv =
+    let parser = ArgumentParser.Create<GitArgs>(programName = "git")
+    printfn "=== Schema for 'git' ==="
+    dump 0 parser
+    printfn ""
+    printfn "=== Help text ==="
+    printfn "%s" (parser.PrintUsage())
+    0


### PR DESCRIPTION
## Summary

A new console sample under `samples/Argu.Samples.Introspect/` that walks an `ArgumentParser`'s schema:

- `GetArgumentCases()` enumerates each case's `ArgumentCaseInfo`.
- `GetSubCommandParsers()` returns the untyped child parsers.
- `IArgumentParserVisitor<'R>` recovers the typed parser when only the untyped base is in scope.

The sample defines a minimal git-style schema (commit, push), prints every case at every nesting level, then prints the generated help text for comparison.

## Why

There's no in-repo example showing how to walk a parser's schema. The pieces are documented individually but the assembly is left to the user.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet run --project samples/Argu.Samples.Introspect` — emits readable schema dump
- [x] `dotnet test -c Release` — 112/112 pass