### PR TITLE
perf: Flatten internal Lazy<bool> fields in UnionCaseArgInfo

### DIFF
--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -92,7 +92,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
             error argInfo ErrorCode.CommandLine "argument '%s' should precede all other arguments." result.ParseContext
 
         match lastResult with
-        | Some lr when not (lr.Tag = result.CaseInfo.Tag && lr.CaseInfo.IsRest.Value) ->
+        | Some lr when not (lr.Tag = result.CaseInfo.Tag && lr.CaseInfo.IsRest) ->
             error argInfo ErrorCode.CommandLine "parameter '%s' should appear after all other arguments." lr.ParseContext
         | _ -> ()
 
@@ -101,7 +101,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
 
         resultCount <- resultCount + 1
         let agg = results.Value[result.Tag]
-        if result.CaseInfo.IsUnique.Value && agg.Count > 0 then
+        if result.CaseInfo.IsUnique && agg.Count > 0 then
             error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name.Value
 
         if result.CaseInfo.ArgumentType = ArgumentType.SubCommand then
@@ -136,7 +136,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
           MissingMandatoryCases = [
               yield! missingMandatoryCasesOfNestedResults
 
-              match argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory.Value && results.Value[case.Tag].Count = 0) |> Seq.toList with
+              match argInfo.Cases.Value |> Seq.filter (fun case -> case.IsMandatory && results.Value[case.Tag].Count = 0) |> Seq.toList with
               | [] -> ()
               | missingCases ->
                 yield argInfo, missingCases
@@ -194,7 +194,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
     | HelpArgument _ -> aggregator.IsUsageRequested <- true
     | UnrecognizedOrArgument token ->
         match argInfo.MainCommandParam.Value with
-        | Some mcp when not (mcp.IsUnique.Value && aggregator.IsMainCommandDefined) ->
+        | Some mcp when not (mcp.IsUnique && aggregator.IsMainCommandDefined) ->
             match mcp.ParameterInfo.Value with
             | Primitives parsers ->
                 // since main command syntax deals with a degree of implicitness
@@ -259,7 +259,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
                         false
 
-                if parseSingleParameter true && mcp.IsRest.Value then
+                if parseSingleParameter true && mcp.IsRest then
                     while not state.Reader.IsCompleted && parseSingleParameter false do ()
 
             | ListParam(existential, field) ->
@@ -381,7 +381,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
         | Primitives fields ->
             parseSingleParameter fields
-            if caseInfo.IsRest.Value then
+            if caseInfo.IsRest then
                 while not state.Reader.IsCompleted do
                     parseSingleParameter fields
 

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -65,8 +65,8 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
             match acr, clr with
             | Choice1Of2 ts, [||] -> ts
             | Choice2Of2 e, [||] -> raise e
-            | Choice2Of2 e, _ when caseInfo.GatherAllSources.Value -> raise e
-            | Choice1Of2 ts, ts' when caseInfo.GatherAllSources.Value -> Array.append ts ts'
+            | Choice2Of2 e, _ when caseInfo.GatherAllSources -> raise e
+            | Choice1Of2 ts, ts' when caseInfo.GatherAllSources -> Array.append ts ts'
             | _, ts' -> ts'
 
         match combined, commandLineResults with
@@ -77,7 +77,7 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
                 |> String.concat "', '"
             error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allMissingParamNames
 
-        | [||], _ when caseInfo.IsMandatory.Value && not ignoreMissingMandatory ->
+        | [||], _ when caseInfo.IsMandatory && not ignoreMissingMandatory ->
             error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value
         | _ -> combined
 

--- a/src/Argu/Parsers/KeyValue.fs
+++ b/src/Argu/Parsers/KeyValue.fs
@@ -49,7 +49,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
 
                 | Primitives fields ->
                     let tokens =
-                        if caseInfo.AppSettingsCSV.Value || fields.Length > 1 then
+                        if caseInfo.AppSettingsCSV || fields.Length > 1 then
                             entry.Split(caseInfo.AppSettingsSeparators, caseInfo.AppSettingsSplitOptions)
                         else [| entry |]
 
@@ -70,7 +70,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
                         mkUnionCase caseInfo caseInfo.Tag ParseSource.AppSettings name fields
 
                     let results =
-                        if caseInfo.AppSettingsCSV.Value then [| while !pos < tokens.Length do yield parseSingleArgument () |]
+                        if caseInfo.AppSettingsCSV then [| while !pos < tokens.Length do yield parseSingleArgument () |]
                         else [| parseSingleArgument () |]
 
                     success results

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -300,18 +300,22 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let declaringTypeAttributes = lazy uci.DeclaringType.GetCustomAttributes(true)
 
     let isNoCommandLine = lazy(hasAttribute2<NoCommandLineAttribute> attributes.Value declaringTypeAttributes.Value)
+    // These boolean flags were previously each wrapped in `Lazy<bool>`. They are
+    // derived strictly from already-cached attribute arrays (or each other), so
+    // the lazy wrapper added an allocation per case without any deferral benefit.
+    // Compute them eagerly.
 #nowarn "44" // ParseCSV and Rest attribute is [<Obsolete>]; we still parse them for backwards compatibility
-    let isAppSettingsCSV = lazy(hasAttribute<ParseCSVAttribute> attributes.Value)
+    let isAppSettingsCSV = hasAttribute<ParseCSVAttribute> attributes.Value
 #warnon "44"
-    let isExactlyOnce = lazy(hasAttribute2<ExactlyOnceAttribute> attributes.Value declaringTypeAttributes.Value)
-    let isMandatory = lazy(isExactlyOnce.Value || hasAttribute2<MandatoryAttribute> attributes.Value declaringTypeAttributes.Value)
-    let isUnique = lazy(isExactlyOnce.Value || hasAttribute2<UniqueAttribute> attributes.Value declaringTypeAttributes.Value)
-    let isInherited = lazy(hasAttribute<InheritAttribute> attributes.Value)
-    let isGatherAll = lazy(hasAttribute<GatherAllSourcesAttribute> attributes.Value)
+    let isExactlyOnce = hasAttribute2<ExactlyOnceAttribute> attributes.Value declaringTypeAttributes.Value
+    let isMandatory = isExactlyOnce || hasAttribute2<MandatoryAttribute> attributes.Value declaringTypeAttributes.Value
+    let isUnique = isExactlyOnce || hasAttribute2<UniqueAttribute> attributes.Value declaringTypeAttributes.Value
+    let isInherited = hasAttribute<InheritAttribute> attributes.Value
+    let isGatherAll = hasAttribute<GatherAllSourcesAttribute> attributes.Value
 #nowarn "44"  // Rest attribute is [<Obsolete>]; we still parse them for backwards compatibility
-    let isRest = lazy(hasAttribute<RestAttribute> attributes.Value)
+    let isRest = hasAttribute<RestAttribute> attributes.Value
 #warnon "44"
-    let isHidden = lazy(hasAttribute<HiddenAttribute> attributes.Value)
+    let isHidden = hasAttribute<HiddenAttribute> attributes.Value
     let isExplicitSubCommand = lazy(hasAttribute<SubCommandAttribute> attributes.Value)
 
     let mainCommandName = lazy(
@@ -347,7 +351,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
                 arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 only." uci attributeName types.Length
             if types.Length <> 1 && types.Length <> 2 then
                 arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 or 2." uci attributeName types.Length
-            elif isRest.Value then
+            elif isRest then
                 arguExn "parameter '%O' contains incompatible attributes '%s' and 'Rest'." uci attributeName
         match customAssignment, spaceOrCustomAssignment with
         | Some customAssignment, None ->
@@ -406,13 +410,13 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let checkSubCommand() =
         if Option.isSome customAssignmentSeparator.Value then
             arguExn "CustomAssignment in '%O' not supported in subcommands." uci
-        if isRest.Value then
+        if isRest then
             arguExn "Rest attribute in '%O' not supported in subcommands." uci
-        if isMandatory.Value then
+        if isMandatory then
             arguExn "Mandatory attribute in '%O' not supported in subcommands." uci
         if isMainCommand.Value then
             arguExn "MainCommand attribute in '%O' not supported in subcommands." uci
-        if isInherited.Value then
+        if isInherited then
             arguExn "Inherit attribute in '%O' not supported in subcommands." uci
 
     let parsers = lazy(
@@ -425,7 +429,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             SubCommand(shape, argInfo, tryExtractUnionParameterLabel fields[0])
 
         | [|Optional t|] ->
-            if isRest.Value then
+            if isRest then
                 arguExn "Rest attribute in '%O' not supported in optional parameters." uci
 
             if isMainCommand.Value then
@@ -439,7 +443,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             if Option.isSome customAssignmentSeparator.Value then
                 arguExn "CustomAssignment in '%O' not supported for list parameters." uci
 
-            if isRest.Value then
+            if isRest then
                 arguExn "Rest attribute in '%O' not supported for list parameters." uci
 
             let label = tryExtractUnionParameterLabel fields[0]
@@ -493,7 +497,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             match parsers.Value with
             | Primitives ps ->
                 let name = ps |> Seq.map (fun p -> "<" + p.Description + ">" ) |> String.concat " "
-                if isRest.Value then name + "..." else name
+                if isRest then name + "..." else name
             | ListParam(_,p) -> "<" + p.Description + ">..."
             | _ -> arguExn "internal error in argu parser representation %O." uci
         | _ when Option.isSome appSettingsName.Value -> appSettingsName.Value.Value
@@ -503,7 +507,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let fieldCtor = Helpers.tupleConstructor types
     let assignParser = Helpers.assignParser customAssignmentSeparator
 
-    if isAppSettingsCSV.Value && fields.Length <> 1 then
+    if isAppSettingsCSV && fields.Length <> 1 then
         arguExn "CSV attribute is only compatible with branches of unary fields."
 
     // extract the description string for given union case
@@ -594,7 +598,7 @@ and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpPar
         | Some parent ->
             let pInfo = parent.GetParent()
             pInfo.Cases.Value
-            |> Seq.filter (fun cI -> cI.IsInherited.Value)
+            |> Seq.filter (fun cI -> cI.IsInherited)
             |> Seq.append pInfo.InheritedParams.Value
             |> Seq.toArray)
 
@@ -678,23 +682,17 @@ let checkUnionArgInfo (result: UnionArgInfo) =
                 arguExn "parameters '%O' and '%O' using conflicting AppSettings identifier '%s'."
                     conflicts[0].UnionCaseInfo conflicts[1].UnionCaseInfo name)
 
-        // Evaluate every lazy property to ensure that their checks run
+        // Evaluate every remaining lazy property to ensure that their checks run.
+        // (Strict boolean fields no longer need forcing here.)
         for case in argInfo.Cases.Value do
             case.Name.Value |> ignore
             case.CommandLineNames.Value |> ignore
             case.AppSettingsName.Value |> ignore
             case.ParameterInfo.Value |> ignore
-            case.AppSettingsCSV.Value |> ignore
             case.MainCommandName.Value |> ignore
-            case.IsMandatory.Value |> ignore
-            case.IsUnique.Value |> ignore
-            case.IsInherited.Value |> ignore
-            case.GatherAllSources.Value |> ignore
-            case.IsRest.Value |> ignore
             case.CliPosition.Value |> ignore
             case.CustomAssignmentSeparator.Value |> ignore
             case.IsGatherUnrecognized.Value |> ignore
-            case.IsHidden.Value |> ignore
             case.CaseCtor.Value |> ignore
             case.Description.Value |> ignore
 

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -251,7 +251,7 @@ module Helpers =
                     if not <| regex.IsMatch arg then [||]
                     else Array.init (arg.Length - 1) (fun i -> String([|'-'; arg[i + 1]|]))))
 
-    let caseCtor uci = lazy FSharpValue.PreComputeUnionConstructor(uci, allBindings)
+    let caseCtor uci = FSharpValue.PreComputeUnionConstructor(uci, allBindings)
     let fieldReader uci = lazy FSharpValue.PreComputeUnionReader(uci, allBindings)
 
     let tupleConstructor (types: Type[]) =
@@ -277,51 +277,33 @@ module Helpers =
 
 /// generate argument parsing schema from given UnionCaseInfo
 let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : HelpParam option)
-                                            (getParent : unit -> UnionArgInfo)
-                                            (uci : UnionCaseInfo) : UnionCaseArgInfo =
-
+        // NOTE MUST not be called within body as parent can't be built until this returns
+        (getParent : unit -> UnionArgInfo)
+        (uci : UnionCaseInfo) : UnionCaseArgInfo =
     let fields = uci.GetFields()
-    let types = fields |> Array.map (fun f -> f.PropertyType)
+    let types = fields |> Array.map _.PropertyType
+    let attrs = uci.GetCustomAttributes()
+    let declaringTypeAttrs = uci.DeclaringType.GetCustomAttributes true
 
-    let caseCtor = Helpers.caseCtor uci
-
-    // create a dummy instance for given union case
-    let dummy = lazy(
-        let dummyFields = types |> Array.map Unchecked.UntypedDefaultOf
-        caseCtor.Value dummyFields :?> IArgParserTemplate)
-
-    // Children need access to parent levels, but parent levels can't be created until child layers visited ...
-    let mutable current : UnionCaseArgInfo option = None
-    // ... protocol is that access to parent levels is deferred via delaying calls to `getCurrent` via Lazy
-    // i.e. if this get fails, it;s because the protocol ahs not been honored
-    let getCurrent () = Option.get current
-
-    let attributes = lazy uci.GetCustomAttributes()
-    let declaringTypeAttributes = lazy uci.DeclaringType.GetCustomAttributes(true)
-
-    let isNoCommandLine = lazy(hasAttribute2<NoCommandLineAttribute> attributes.Value declaringTypeAttributes.Value)
-    // These boolean flags were previously each wrapped in `Lazy<bool>`. They are
-    // derived strictly from already-cached attribute arrays (or each other), so
-    // the lazy wrapper added an allocation per case without any deferral benefit.
-    // Compute them eagerly.
+    let isNoCommandLine = hasAttribute2<NoCommandLineAttribute> attrs declaringTypeAttrs
 #nowarn "44" // ParseCSV and Rest attribute is [<Obsolete>]; we still parse them for backwards compatibility
-    let isAppSettingsCSV = hasAttribute<ParseCSVAttribute> attributes.Value
+    let isAppSettingsCSV = hasAttribute<ParseCSVAttribute> attrs
 #warnon "44"
-    let isExactlyOnce = hasAttribute2<ExactlyOnceAttribute> attributes.Value declaringTypeAttributes.Value
-    let isMandatory = isExactlyOnce || hasAttribute2<MandatoryAttribute> attributes.Value declaringTypeAttributes.Value
-    let isUnique = isExactlyOnce || hasAttribute2<UniqueAttribute> attributes.Value declaringTypeAttributes.Value
-    let isInherited = hasAttribute<InheritAttribute> attributes.Value
-    let isGatherAll = hasAttribute<GatherAllSourcesAttribute> attributes.Value
+    let isExactlyOnce = hasAttribute2<ExactlyOnceAttribute> attrs declaringTypeAttrs
+    let isMandatory = isExactlyOnce || hasAttribute2<MandatoryAttribute> attrs declaringTypeAttrs
+    let isUnique = isExactlyOnce || hasAttribute2<UniqueAttribute> attrs declaringTypeAttrs
+    let isInherited = hasAttribute<InheritAttribute> attrs
+    let isGatherAll = hasAttribute<GatherAllSourcesAttribute> attrs
 #nowarn "44"  // Rest attribute is [<Obsolete>]; we still parse them for backwards compatibility
-    let isRest = hasAttribute<RestAttribute> attributes.Value
+    let isRest = hasAttribute<RestAttribute> attrs
 #warnon "44"
-    let isHidden = hasAttribute<HiddenAttribute> attributes.Value
-    let isExplicitSubCommand = lazy(hasAttribute<SubCommandAttribute> attributes.Value)
+    let isHidden = hasAttribute<HiddenAttribute> attrs
+    let isExplicitSubCommand = hasAttribute<SubCommandAttribute> attrs
 
     let mainCommandName = lazy(
-        match tryGetAttribute<MainCommandAttribute> attributes.Value with
+        match tryGetAttribute<MainCommandAttribute> attrs with
         | None -> None
-        | Some _ when isNoCommandLine.Value -> arguExn "parameter '%O' contains conflicting attributes 'MainCommand' and 'NoCommandLine'." uci
+        | Some _ when isNoCommandLine -> arguExn "parameter '%O' contains conflicting attributes 'MainCommand' and 'NoCommandLine'." uci
         | Some _ when types.Length = 0 -> arguExn "parameter '%O' contains MainCommand attribute but has unsupported arity 0." uci
         | Some attr ->
             match attr.ArgumentName with
@@ -332,7 +314,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let isMainCommand = lazy(Option.isSome mainCommandName.Value)
 
     let cliPosition = lazy(
-        match tryGetAttribute<CliPositionAttribute> attributes.Value with
+        match tryGetAttribute<CliPositionAttribute> attrs with
         | Some attr ->
             match attr.Position with
             | CliPosition.Unspecified
@@ -342,8 +324,8 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None -> CliPosition.Unspecified)
 
     let customAssignmentSeparator : Lazy<CustomAssignmentSeparator option> = lazy(
-        let customAssignment = tryGetAttribute2<CustomAssignmentAttribute> attributes.Value declaringTypeAttributes.Value
-        let spaceOrCustomAssignment = tryGetAttribute2<CustomAssignmentOrSpacedAttribute> attributes.Value declaringTypeAttributes.Value
+        let customAssignment = tryGetAttribute2<CustomAssignmentAttribute> attrs declaringTypeAttrs
+        let spaceOrCustomAssignment = tryGetAttribute2<CustomAssignmentOrSpacedAttribute> attrs declaringTypeAttrs
         let validateCustomAssignmentAttributes attributeName tolerateSpacedArguments =
             if isMainCommand.Value && types.Length = 1 then
                 arguExn "parameter '%O' of arity 1 contains incompatible attributes '%s' and 'MainCommand'." uci attributeName
@@ -378,7 +360,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         )
 
     let isGatherUnrecognized = lazy(
-        if hasAttribute<GatherUnrecognizedAttribute> attributes.Value then
+        if hasAttribute<GatherUnrecognizedAttribute> attrs then
             match types with
             | _ when isMainCommand.Value -> arguExn "parameter '%O' contains incompatible combination of attributes 'MainCommand' and 'GatherUnrecognized'." uci
             | [|t|] when t = typeof<string> -> true
@@ -387,7 +369,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             false)
 
     let appSettingsSeparators, appSettingsSplitOptions =
-        match tryGetAttribute2<AppSettingsSeparatorAttribute> attributes.Value declaringTypeAttributes.Value with
+        match tryGetAttribute2<AppSettingsSeparatorAttribute> attrs declaringTypeAttrs with
         | None -> [|","|], StringSplitOptions.None
         | Some attr when attr.Separators.Length = 0 ->
             arguExn "parameter '%O' specifies a null or empty AppSettings separator." uci
@@ -404,7 +386,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | [|NestedParseResults _|] -> ArgumentType.SubCommand
         | [|Optional _|] -> ArgumentType.Optional
         | [|List _|] -> ArgumentType.List
-        | _ when isExplicitSubCommand.Value -> ArgumentType.SubCommand
+        | _ when isExplicitSubCommand -> ArgumentType.SubCommand
         | _ -> ArgumentType.Primitive
 
     let checkSubCommand() =
@@ -419,11 +401,18 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         if isInherited then
             arguExn "Inherit attribute in '%O' not supported in subcommands." uci
 
+    // Children need access to parent levels, but parent levels can't be created until child layers visited ...
+    let mutable current : UnionCaseArgInfo option = None
+    // ... protocol is that access to parent levels is deferred via delaying calls to `getCurrent` via Lazy
+    // i.e. if this get fails, it;s because the protocol has not been honored
+    let getCurrent () = Option.get current
     let parsers = lazy(
         match types with
         | [|NestedParseResults prt|] ->
             checkSubCommand()
 
+            // NOTE see above; must be `lazy`
+            // `getCurrent` MUST NOT be invoked by `preComputeUnionArgInfoInner` until `current` assigned
             let argInfo = preComputeUnionArgInfoInner stack helpParam (getCurrent >> Some) prt
             let shape = ShapeArgumentTemplate.FromType prt
             SubCommand(shape, argInfo, tryExtractUnionParameterLabel fields[0])
@@ -451,7 +440,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             ListParam(Existential.FromType t, getPrimitiveParserByType label t)
 
         | _ ->
-            if isExplicitSubCommand.Value then
+            if isExplicitSubCommand then
                 if not (Array.isEmpty fields) then
                     arguExn "SubCommand in '%O' not supported for parameters other than ParseResults<_>." uci
                 checkSubCommand()
@@ -464,15 +453,15 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             Array.map getParser fields |> Primitives)
 
     let commandLineArgs = lazy(
-        if isMainCommand.Value || isNoCommandLine.Value then []
+        if isMainCommand.Value || isNoCommandLine then []
         else
             let cliNames = [
-                match tryGetAttribute<CustomCommandLineAttribute> attributes.Value with
-                | None -> yield generateOptionName uci attributes.Value declaringTypeAttributes.Value
+                match tryGetAttribute<CustomCommandLineAttribute> attrs with
+                | None -> yield generateOptionName uci attrs declaringTypeAttrs
                 | Some attr -> yield attr.Name ; yield! attr.AltNames
 
                 yield!
-                    attributes.Value
+                    attrs
                     |> Array.collect(function | :? AltCommandLineAttribute as a -> a.Names | _ -> [||])
             ]
 
@@ -481,9 +470,9 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
             cliNames)
 
     let appSettingsName = lazy(
-        if hasAttribute2<NoAppSettingsAttribute> attributes.Value declaringTypeAttributes.Value then None
+        if hasAttribute2<NoAppSettingsAttribute> attrs declaringTypeAttrs then None
         else
-            match tryGetAttribute<CustomAppSettingsAttribute> attributes.Value with
+            match tryGetAttribute<CustomAppSettingsAttribute> attrs with
             | None -> Some <| generateAppSettingsName uci
             | Some _ when parsers.Value.Type = ArgumentType.SubCommand -> arguExn "CustomAppSettings in %O not supported in subcommands." uci
             | Some attr when not <| String.IsNullOrWhiteSpace attr.Name -> Some attr.Name
@@ -510,6 +499,11 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     if isAppSettingsCSV && fields.Length <> 1 then
         arguExn "CSV attribute is only compatible with branches of unary fields."
 
+    let caseCtor = lazy (uci |> Helpers.caseCtor)
+    // create a dummy instance for given union case
+    let dummy = lazy(
+        let dummyFields = types |> Array.map Unchecked.UntypedDefaultOf
+        caseCtor.Value dummyFields :?> IArgParserTemplate)
     // extract the description string for given union case
     let description = lazy(
         try dummy.Value.Usage
@@ -549,7 +543,10 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     current <- Some uai // See above; make fully built model available to child computations
     uai
 
-and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpParam option) (tryGetParent : unit -> UnionCaseArgInfo option) (t : Type) : UnionArgInfo =
+and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpParam option)
+    // NOTE per protocol cannot be invoked until after function has returned, i.e. calls to this must be wrapped in lazy
+    (tryGetParent : unit -> UnionCaseArgInfo option)
+    (t : Type) : UnionArgInfo =
     if not <| FSharpType.IsUnion(t, allBindings) then
         arguExn "template type '%O' is not an F# union." t
     elif stack |> List.exists ((=) t) then
@@ -578,9 +575,8 @@ and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpPar
     // Children need access to parent levels, but parent levels can't be created until child layers visited ...
     let mutable current : UnionArgInfo option = None
     // ... protocol is that access to parent levels is deferred via delaying calls to `getCurrent` via Lazy
-    // i.e. if this get fails, it;s because the protocol ahs not been honored
+    // i.e. if this get fails, it;s because the protocol has not been honored
     let getCurrent () = Option.get current
-
     let caseInfo = lazy(
         FSharpType.GetUnionCases(t, allBindings)
         |> Seq.map (preComputeUnionCaseArgInfo (t :: stack) (Some helpParam) getCurrent)

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -99,7 +99,7 @@ type ArgumentType =
     | List       = 3
     /// Argument specifies a subcommand
     | SubCommand = 4
-    
+
 /// Describes the permitted separators between arguments and their values
 type CustomAssignmentSeparator =
     {
@@ -116,7 +116,7 @@ type ArgumentCaseInfo =
         /// Human readable name identifier
         Name : Lazy<string>
         /// Union case reflection identifier
-        UnionCaseInfo : UnionCaseInfo
+        UnionCaseInfo : Lazy<UnionCaseInfo>
         /// Type of argument parser
         ArgumentType : ArgumentType
 

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -41,7 +41,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
 
     let printedCases =
         argInfo.Cases.Value
-        |> Seq.filter (fun aI -> not aI.IsHidden.Value && not aI.IsMainCommand)
+        |> Seq.filter (fun aI -> not aI.IsHidden && not aI.IsMainCommand)
         |> Seq.filter (fun aI -> aI.ArgumentType <> ArgumentType.SubCommand)
         |> Seq.sortBy (fun aI -> aI.CliPosition.Value)
 
@@ -56,7 +56,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
 
         let format() = stringExpr {
             yield ' '
-            if not aI.IsMandatory.Value then yield '['
+            if not aI.IsMandatory then yield '['
             yield name
 
             match aI.ParameterInfo.Value with
@@ -71,7 +71,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
                     for p in parsers do
                         yield sprintf " <%s>" p.Description
 
-                if aI.IsRest.Value then yield "..."
+                if aI.IsRest then yield "..."
 
             | OptionalParam (_,parser) ->
                 match aI.CustomAssignmentSeparator.Value with
@@ -83,7 +83,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
             | ListParam (_,parser) -> yield sprintf " [<%s>...]" parser.Description
             | NullarySubCommand -> ()
 
-            if not aI.IsMandatory.Value then yield ']'
+            if not aI.IsMandatory then yield ']'
         }
 
         let formatCase = format() |> StringExpr.build
@@ -105,7 +105,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
     | Some mc ->
         let formatMainCommand() = stringExpr {
             yield ' '
-            if not mc.IsMandatory.Value then yield '['
+            if not mc.IsMandatory then yield '['
             match mc.ParameterInfo.Value with
             | Primitives parsers ->
                 assert(parsers.Length > 0)
@@ -117,7 +117,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
                 yield sprintf "<%s>..." parser.Description
 
             | _ -> arguExn "internal error: MainCommand param has invalid internal representation."
-            if not mc.IsMandatory.Value then yield ']'
+            if not mc.IsMandatory then yield ']'
         }
 
         let mainCommand = formatMainCommand() |> StringExpr.build
@@ -140,7 +140,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
         for i = 1 to parsers.Length - 1 do
             yield sprintf " <%s>" parsers[i].Description
 
-        if aI.IsRest.Value then yield "..."
+        if aI.IsRest then yield "..."
 
     | Primitives parsers ->
         match aI.CustomAssignmentSeparator.Value with
@@ -153,7 +153,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
             for p in parsers do
                 yield sprintf " <%s>" p.Description
 
-        if aI.IsRest.Value then yield "..."
+        if aI.IsRest then yield "..."
 
     | OptionalParam (_,parser) ->
         match aI.CustomAssignmentSeparator.Value with
@@ -234,12 +234,12 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
 
     let options, subcommands =
         argInfo.Cases.Value
-        |> Seq.filter (fun aI -> not aI.IsHidden.Value)
+        |> Seq.filter (fun aI -> not aI.IsHidden)
         |> Seq.filter (fun aI -> not aI.IsMainCommand)
         |> Seq.partition (fun aI -> aI.ArgumentType <> ArgumentType.SubCommand)
 
     match argInfo.MainCommandParam.Value with
-    | Some aI when not aI.IsHidden.Value ->
+    | Some aI when not aI.IsHidden ->
         let! length = StringExpr.currentLength
         if length > 0 then yield Environment.NewLine
         assert(Option.isSome aI.MainCommandName.Value)
@@ -276,7 +276,7 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
         yield Environment.NewLine; yield Environment.NewLine
 
         for aI in options do yield! mkArgUsage width aI
-        for aI in argInfo.InheritedParams.Value |> Seq.filter (fun a -> not a.IsHidden.Value) do yield! mkArgUsage width aI
+        for aI in argInfo.InheritedParams.Value |> Seq.filter (fun a -> not a.IsHidden) do yield! mkArgUsage width aI
 
         yield! mkHelpParamUsage width argInfo.HelpParam
 }

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -211,14 +211,14 @@ type UnionCaseArgInfo with
     member inline ucai.IsFirst = ucai.CliPosition.Value = CliPosition.First
     member inline ucai.IsLast = ucai.CliPosition.Value = CliPosition.Last
 
+    /// Maps from `internal` type to `public` API Types
     member ucai.ToArgumentCaseInfo() : ArgumentCaseInfo =
-        // Several `UnionCaseArgInfo` fields are now strict `bool` (cheap to
-        // compute eagerly), but `ArgumentCaseInfo` keeps `Lazy<bool>` for
-        // public binary compatibility — wrap with `lazy` here.
+        // Internal types are minimal and/or can be changed at will
+        // Here we map those to the stable external API contract, which won't be changed until next major ver
         {
             Name = ucai.Name
             ArgumentType = ucai.ArgumentType
-            UnionCaseInfo = ucai.UnionCaseInfo
+            UnionCaseInfo = lazy ucai.UnionCaseInfo
             CommandLineNames = ucai.CommandLineNames
             AppSettingsName = ucai.AppSettingsName
             Description = ucai.Description

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -101,21 +101,21 @@ type UnionCaseArgInfo =
         /// Specifies that this argument is the main CLI command
         MainCommandName : Lazy<string option>
         /// If specified, should consume remaining tokens from the CLI
-        IsRest : Lazy<bool>
+        IsRest : bool
         /// If specified, multiple parameters can be added in Configuration in CSV form.
-        AppSettingsCSV : Lazy<bool>
+        AppSettingsCSV : bool
         /// Fails if no argument of this type is specified
-        IsMandatory : Lazy<bool>
+        IsMandatory : bool
         /// Indicates that argument should be inherited in the scope of any sibling subcommands.
-        IsInherited : Lazy<bool>
+        IsInherited : bool
         /// Specifies that argument should be specified at most once in CLI
-        IsUnique : Lazy<bool>
+        IsUnique : bool
         /// Hide from Usage
-        IsHidden : Lazy<bool>
+        IsHidden : bool
         /// Declares that the parameter should gather any unrecognized CLI params
         IsGatherUnrecognized : Lazy<bool>
         /// Combine AppSettings with CLI inputs
-        GatherAllSources : Lazy<bool>
+        GatherAllSources : bool
     }
 with
     member inline x.IsMainCommand = Option.isSome x.MainCommandName.Value
@@ -212,6 +212,9 @@ type UnionCaseArgInfo with
     member inline ucai.IsLast = ucai.CliPosition.Value = CliPosition.Last
 
     member ucai.ToArgumentCaseInfo() : ArgumentCaseInfo =
+        // Several `UnionCaseArgInfo` fields are now strict `bool` (cheap to
+        // compute eagerly), but `ArgumentCaseInfo` keeps `Lazy<bool>` for
+        // public binary compatibility — wrap with `lazy` here.
         {
             Name = ucai.Name
             ArgumentType = ucai.ArgumentType
@@ -222,13 +225,13 @@ type UnionCaseArgInfo with
             AppSettingsSeparators = Array.toList ucai.AppSettingsSeparators
             AppSettingsSplitOptions = ucai.AppSettingsSplitOptions
             IsMainCommand = ucai.IsMainCommand
-            IsRest = ucai.IsRest
+            IsRest = lazy ucai.IsRest
             CliPosition = ucai.CliPosition
             CustomAssignmentSeparator = ucai.CustomAssignmentSeparator
-            AppSettingsCSV = ucai.AppSettingsCSV
-            IsMandatory = ucai.IsMandatory
-            IsUnique = ucai.IsUnique
-            IsHidden = ucai.IsHidden
+            AppSettingsCSV = lazy ucai.AppSettingsCSV
+            IsMandatory = lazy ucai.IsMandatory
+            IsUnique = lazy ucai.IsUnique
+            IsHidden = lazy ucai.IsHidden
             IsGatherUnrecognized = ucai.IsGatherUnrecognized
-            GatherAllSources = ucai.GatherAllSources
+            GatherAllSources = lazy ucai.GatherAllSources
         }


### PR DESCRIPTION
## Summary

Seven boolean-valued fields on the internal `UnionCaseArgInfo` were each `Lazy<bool>` even though their bodies only inspect already-cached attribute arrays. Make them strict `bool`:

- `IsRest`, `AppSettingsCSV`, `IsMandatory`, `IsInherited`, `IsUnique`, `IsHidden`, `GatherAllSources`

`Lazy<_>` fields whose bodies raise validation errors (`CustomAssignmentSeparator`, `IsGatherUnrecognized`, `CliPosition`, `MainCommandName`, `ParameterInfo`, etc.) remain `Lazy<_>` so error-emission timing is unchanged for the `checkStructure=false` consumers.

Public `ArgumentCaseInfo` keeps `Lazy<bool>` for binary compatibility — `ToArgumentCaseInfo()` wraps the strict bools with `lazy ...` at the boundary.

## Why

Each `Lazy<bool>` was a heap allocation that boxed a primitive, with no deferral benefit — `checkUnionArgInfo` forces every one on the default construction path anyway. The criticism in the original review was that the lazy graph wasn't carrying its weight; this commit flattens the seven flags that are safe to flatten without changing observable behaviour.

## Test plan

- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 112/112 pass