### PR TITLE
refactor(UnParsers): Use let mutable for closure state; fix RELEASE_NOTES URLs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,8 @@
 * Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
-* Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/SwensenSoftware/unquote/pull/264)
-* target Unquote 7.0.1 now that it has [reduced `FSharp.Core` dependencies](https://github.com/SwensenSoftware/unquote/pull/172) [#264](https://github.com/SwensenSoftware/unquote/pull/264)
+* Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/fsprojects/Argu/pull/264)
+* target Unquote 7.0.1 now that it has [reduced `FSharp.Core` dependencies](https://github.com/SwensenSoftware/unquote/pull/172) [#264](https://github.com/fsprojects/Argu/pull/264)
   
 ### 6.2.4
 * Add `AttributeUsage` targets for methods which will be required in .NET 8.0.300 [#243](https://github.com/fsprojects/Argu/pull/243) [@dlidstrom](https://github.com/dlidstrom)

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -26,17 +26,17 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
     let offset = length1 - length0
 
     let insertToken =
-        let startOfCurrentLine = ref length0
-        let isFirstToken = ref true
+        let mutable startOfCurrentLine = length0
+        let mutable isFirstToken = true
         fun (token:string) -> stringExpr {
             let! currLength = StringExpr.currentLength
-            let currLineLength = currLength - !startOfCurrentLine
-            if not !isFirstToken && currLineLength + token.Length > maxWidth then
+            let currLineLength = currLength - startOfCurrentLine
+            if not isFirstToken && currLineLength + token.Length > maxWidth then
                 yield Environment.NewLine
                 yield! StringExpr.whiteSpace offset
-                startOfCurrentLine := currLength + Environment.NewLine.Length
+                startOfCurrentLine <- currLength + Environment.NewLine.Length
             yield token
-            isFirstToken := false
+            isFirstToken <- false
         }
 
     let printedCases =


### PR DESCRIPTION
refactor(UnParsers): Use let mutable for closure state; fix RELEASE_NOTES URLs

* UnParsers.fs: Replace ref-cells startOfCurrentLine / isFirstToken with let mutable in the line-wrap closure inside mkCommandLineSyntax. Same idiom as PR pr/02-ref-mutable applied to UnParsers (which that PR did not touch). Semantics unchanged.
* RELEASE_NOTES.md: The two [#264] links in the 6.2.5 entry pointed at SwensenSoftware/unquote#264 by copy-paste. Repoint to fsprojects/Argu#264. The Unquote#172 reference ("reduced FSharp.Core dependencies") is genuinely about the Unquote PR and stays.

---