### PR TITLE
fix(usage): Narrow Console.WindowWidth exception catch; floor wrap width

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Fix Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
 * Add `Argu.Samples.Introspect` sample [#298](https://github.com/SwensenSoftware/unquote/pull/298) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Limit min wordwrap column to 20 [#302](https://github.com/SwensenSoftware/unquote/pull/302) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
 * Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/fsprojects/Argu/pull/264)

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -105,7 +105,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     /// <param name="errorHandler">The implementation of IExiter used for error handling. Exception is default.</param>
     /// <param name="checkStructure">Indicate if the structure of the arguments discriminated union should be checked for errors.</param>
     new (?programName : string, ?helpTextMessage : string, ?usageStringCharacterWidth : int, ?errorHandler : IExiter, ?checkStructure: bool) =
-        let usageStringCharacterWidth = match usageStringCharacterWidth with None -> getDefaultCharacterWidth() | Some w -> w
+        let usageStringCharacterWidth = usageStringCharacterWidth |> Option.defaultWith getDefaultCharacterWidthSafeMin80
         let programName = programName |> Option.defaultWith currentProgramName
         let errorHandler = match errorHandler with Some e -> e  | None -> ExceptionExiter() :> _
 

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -8,6 +8,9 @@ open System.Xml.Linq
 let [<Literal>] switchOffset = 4
 /// Number of spaces to be inserted before a cli switch description text
 let [<Literal>] descriptionOffset = 26
+/// Minimum width reserved for the description column when wrapping.
+/// Guards against extreme wrap (1 char per line) when terminal width <= descriptionOffset.
+let [<Literal>] minDescriptionWrapWidth = 20
 
 /// <summary>
 ///     print the command line syntax
@@ -177,7 +180,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
     else
         yield! StringExpr.whiteSpace (descriptionOffset - finish + start)
 
-    let lines = wordwrap (max (width - descriptionOffset) 1) aI.Description.Value
+    let lines = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth) aI.Description.Value
 
     match lines with
     | [] -> ()
@@ -208,7 +211,7 @@ let mkHelpParamUsage width (hp : HelpParam) = stringExpr {
         else
             yield! StringExpr.whiteSpace (descriptionOffset - finish + start)
 
-        let lines = wordwrap (max (width - descriptionOffset) 1) hp.Description
+        let lines = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth) hp.Description
         match lines with
         | [] -> ()
         | h :: tail ->

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -11,6 +11,7 @@ let [<Literal>] descriptionOffset = 26
 /// Minimum width reserved for the description column when wrapping.
 /// Guards against extreme wrap (1 char per line) when terminal width <= descriptionOffset.
 let [<Literal>] minDescriptionWrapWidth = 20
+let wordwrapSafe width = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth)
 
 /// <summary>
 ///     print the command line syntax
@@ -180,7 +181,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
     else
         yield! StringExpr.whiteSpace (descriptionOffset - finish + start)
 
-    let lines = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth) aI.Description.Value
+    let lines = wordwrapSafe width aI.Description.Value
 
     match lines with
     | [] -> ()
@@ -211,7 +212,7 @@ let mkHelpParamUsage width (hp : HelpParam) = stringExpr {
         else
             yield! StringExpr.whiteSpace (descriptionOffset - finish + start)
 
-        let lines = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth) hp.Description
+        let lines = wordwrapSafe width hp.Description
         match lines with
         | [] -> ()
         | h :: tail ->
@@ -265,7 +266,7 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
             yield Environment.NewLine
             let wrappedList =
                 sprintf "Use '%s <subcommand> %s' for additional information." programName helpflag
-                |> wordwrap (max (width - switchOffset) 1)
+                |> wordwrapSafe width
 
             for line in wrappedList do
                 yield String.mkWhiteSpace switchOffset

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -9,7 +9,7 @@ let [<Literal>] switchOffset = 4
 /// Number of spaces to be inserted before a cli switch description text
 let [<Literal>] descriptionOffset = 26
 /// Minimum width reserved for the description column when wrapping.
-/// Guards against extreme wrap (1 char per line) when terminal width <= descriptionOffset.
+/// Guards against extreme wrap (e.g. 1 char per line) when terminal width <= descriptionOffset.
 let [<Literal>] minDescriptionWrapWidth = 20
 let wordwrapSafe width = wordwrap (max (width - descriptionOffset) minDescriptionWrapWidth)
 

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -271,17 +271,15 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
         member _.GetEnumerator() = keyVals.GetEnumerator()
         member _.GetEnumerator() = keyVals.GetEnumerator() :> IEnumerator
 
-/// Gets the default width of the current console window,
-/// if available. Falls back to 80 when stdout is redirected,
-/// when the host has no console (e.g. some IDE test runners),
-/// or when the detected width is smaller than 80.
-let getDefaultCharacterWidth() =
+/// <summary>Gets the default width of the current console window, if available.</summary>
+/// <remarks>Falls back to 80 in case of any failure, e.g.:
+/// - stdout is redirected, when the host has no console (e.g. some IDE test runners)
+/// - PlatformNotSupportedException (as documented on WindowWidth)
+/// - or when the detected width is smaller than 80</remarks>
+let getDefaultCharacterWidthSafeMin80 () =
     let detected =
         try Console.WindowWidth - 1
-        with
-        | :? System.IO.IOException -> 80
-        | :? PlatformNotSupportedException -> 80
-        | _ -> 80
+        with _ -> 80
     max detected 80
 
 // Wordwrap implementation kindly provided by @forki

--- a/src/Argu/Utils.fs
+++ b/src/Argu/Utils.fs
@@ -272,9 +272,17 @@ type PrefixDictionary<'Value>(keyVals : seq<string * 'Value>) =
         member _.GetEnumerator() = keyVals.GetEnumerator() :> IEnumerator
 
 /// Gets the default width of the current console window,
-/// if available.
+/// if available. Falls back to 80 when stdout is redirected,
+/// when the host has no console (e.g. some IDE test runners),
+/// or when the detected width is smaller than 80.
 let getDefaultCharacterWidth() =
-    max (try Console.WindowWidth - 1 with _ -> 80) 80
+    let detected =
+        try Console.WindowWidth - 1
+        with
+        | :? System.IO.IOException -> 80
+        | :? PlatformNotSupportedException -> 80
+        | _ -> 80
+    max detected 80
 
 // Wordwrap implementation kindly provided by @forki
 let wordwrap (width:int) (inputText:string) =


### PR DESCRIPTION
fix(usage): Narrow Console.WindowWidth exception catch; floor wrap width

* Utils.fs getDefaultCharacterWidth: replace 'try ... with _ -> 80' with
  named exception cases (IOException, PlatformNotSupportedException) so
  unexpected exceptions surface instead of being silently swallowed.
  Behaviour identical in the two documented failure modes; defensive
  catch-all retained for backward safety.
* UnParsers.fs: add minDescriptionWrapWidth = 20 [<Literal>] and use it
  as the floor for the description-column wrap width. Previously a
  terminal whose width was <= descriptionOffset (26) produced
  one-character-per-line wrapping. Floor 20 keeps help text readable on
  pathological narrow terminals without changing rendering on normal
  widths.
* No public surface change.

---