### PR TITLE
feat(UsageStrings): Add localisable labels record for usage rendering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 ### 6.2.6
-* Fix NRE in derivation of programName introduced in 6.2.2 [#292](https://github.com/SwensenSoftware/unquote/pull/292) [@dimension-zero](https://github.com/dimension-zero)
-* Fix Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
-* Fix Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
-* Fix Limit min wordwrap column to 20 [#302](https://github.com/SwensenSoftware/unquote/pull/302) [@dimension-zero](https://github.com/dimension-zero)
-* Add `Argu.Samples.Introspect` sample [#298](https://github.com/SwensenSoftware/unquote/pull/298) [@dimension-zero](https://github.com/dimension-zero)
-* Add `ArgumentParser.Parse(ParseConfig)` [#307](https://github.com/SwensenSoftware/unquote/pull/307) [@dimension-zero](https://github.com/dimension-zero)
+* Fix NRE in derivation of programName introduced in 6.2.2 [#292](https://github.com/fsprojects/Argu/pull/292) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Clarify exception in expr2Uci [#293](https://github.com/fsprojects/Argu/pull/293) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Report all missing args in error message, not just first level [#297](https://github.com/fsprojects/Argu/pull/297) [@dimension-zero](https://github.com/dimension-zero)
+* Fix Limit min wordwrap column to 20 [#302](https://github.com/fsprojects/Argu/pull/302) [@dimension-zero](https://github.com/dimension-zero)
+* Add `Argu.Samples.Introspect` sample [#298](https://github.com/fsprojects/Argu/pull/298) [@dimension-zero](https://github.com/dimension-zero)
+* Add `ArgumentParser.Parse(ParseConfig)` [#307](https://github.com/fsprojects/Argu/pull/307) [@dimension-zero](https://github.com/dimension-zero)
+* Add `ArgumentParser.PrintUsage(..., ?UsageStrings)` for localization support [#303](https://github.com/fsprojects/Argu/pull/303) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
 * Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/fsprojects/Argu/pull/264)

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -78,11 +78,13 @@ type ArgumentParser internal (argInfo : UnionArgInfo, _programName : string, hel
     /// <param name="programName">Override the default program name settings.</param>
     /// <param name="hideSyntax">Do not display 'USAGE: [syntax]' at top of usage string. Defaults to false.</param>
     /// <param name="usageStringCharacterWidth">Text width used when formatting the usage string.</param>
-    member _.PrintUsage (?message : string, ?programName : string, ?hideSyntax : bool, ?usageStringCharacterWidth : int) : string =
+    /// <param name="usageStrings">Localisable labels printed by the renderer. Defaults to <c>UsageStrings.Default</c> (English).</param>
+    member _.PrintUsage (?message : string, ?programName : string, ?hideSyntax : bool, ?usageStringCharacterWidth : int, ?usageStrings : UsageStrings) : string =
         let programName = defaultArg programName _programName
         let hideSyntax = defaultArg hideSyntax false
         let usageStringCharacterWidth = defaultArg usageStringCharacterWidth _usageStringCharacterWidth
-        mkUsageString argInfo programName hideSyntax usageStringCharacterWidth message |> StringExpr.build
+        let usageStrings = defaultArg usageStrings UsageStrings.Default
+        mkUsageStringWithLabels argInfo programName hideSyntax usageStringCharacterWidth usageStrings message |> StringExpr.build
 
     /// <summary>
     ///     Prints command line syntax. Useful for generating documentation.

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -89,9 +89,8 @@ type ProcessExiter(colorizerOption : (ErrorCode -> ConsoleColor option) option) 
 
             exit (int errorCode)
 
-/// Localisable labels printed by <c>PrintUsage</c>. Defaults to English via
-/// <c>UsageStrings.Default</c>. Callers may supply a translated record to
-/// render usage in another language.
+/// Localizable labels printed by <c>PrintUsage</c>. Defaults to English via <c>UsageStrings.Default</c>.
+/// Callers may supply a translated record to render usage in another language.
 [<NoEquality; NoComparison>]
 type UsageStrings =
     {
@@ -101,19 +100,17 @@ type UsageStrings =
         Options : string
         /// Header above the subcommands block. Default: <c>"SUBCOMMANDS:"</c>.
         Subcommands : string
-        /// Hint shown below the subcommands list, suggesting how to get
-        /// per-subcommand help. Placeholders: <c>{0}</c> = program name,
-        /// <c>{1}</c> = help flag. Default:
-        /// <c>"Use '{0} &lt;subcommand&gt; {1}' for additional information."</c>
-        SubcommandHelpHint : string
+        /// Hint shown below the subcommands list, suggesting how to get per-subcommand help.<br/>
+        /// Placeholders: <c>{0}</c>: program name, <c>{1}</c>: help flag.<br/>
+        /// Default: /// <c>"Use '{0} &lt;subcommand&gt; {1}' for additional information."</c>
+        SubcommandHelpHintFormat: string
     }
     /// English default labels — preserves the historical wording.
-    static member Default : UsageStrings = {
-        Usage = "USAGE: "
-        Options = "OPTIONS:"
-        Subcommands = "SUBCOMMANDS:"
-        SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information."
-    }
+    static member Default : UsageStrings =
+        {   Usage = "USAGE: "
+            Options = "OPTIONS:"
+            Subcommands = "SUBCOMMANDS:"
+            SubcommandHelpHintFormat = "Use '{0} <subcommand> {1}' for additional information." }
 
 /// Argument parameter type identifier
 type ArgumentType =

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -89,6 +89,32 @@ type ProcessExiter(colorizerOption : (ErrorCode -> ConsoleColor option) option) 
 
             exit (int errorCode)
 
+/// Localisable labels printed by <c>PrintUsage</c>. Defaults to English via
+/// <c>UsageStrings.Default</c>. Callers may supply a translated record to
+/// render usage in another language.
+[<NoEquality; NoComparison>]
+type UsageStrings =
+    {
+        /// Prefix printed before the synopsis line. Default: <c>"USAGE: "</c>.
+        Usage : string
+        /// Header above the options block. Default: <c>"OPTIONS:"</c>.
+        Options : string
+        /// Header above the subcommands block. Default: <c>"SUBCOMMANDS:"</c>.
+        Subcommands : string
+        /// Hint shown below the subcommands list, suggesting how to get
+        /// per-subcommand help. Placeholders: <c>{0}</c> = program name,
+        /// <c>{1}</c> = help flag. Default:
+        /// <c>"Use '{0} &lt;subcommand&gt; {1}' for additional information."</c>
+        SubcommandHelpHint : string
+    }
+    /// English default labels — preserves the historical wording.
+    static member Default : UsageStrings = {
+        Usage = "USAGE: "
+        Options = "OPTIONS:"
+        Subcommands = "SUBCOMMANDS:"
+        SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information."
+    }
+
 /// Argument parameter type identifier
 type ArgumentType =
     /// Argument specifies primitive parameters like strings or integers

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -227,13 +227,13 @@ let mkHelpParamUsage width (hp : HelpParam) = stringExpr {
 /// <summary>
 ///     print usage string for a collection of arg infos
 /// </summary>
-let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax width (message : string option) = stringExpr {
+let mkUsageStringWithLabels (argInfo : UnionArgInfo) (programName : string) hideSyntax width (labels : UsageStrings) (message : string option) = stringExpr {
     match message with
     | Some msg -> yield msg; yield Environment.NewLine
     | None -> ()
 
     if not hideSyntax then
-        yield! mkCommandLineSyntax argInfo "USAGE: " width programName
+        yield! mkCommandLineSyntax argInfo labels.Usage width programName
         yield Environment.NewLine
 
     let options, subcommands =
@@ -255,7 +255,7 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
     if subcommands.Length > 0 then
         let! length = StringExpr.currentLength
         if length > 0 then yield Environment.NewLine
-        yield "SUBCOMMANDS:"
+        yield labels.Subcommands
         yield Environment.NewLine; yield Environment.NewLine
 
         for aI in subcommands do yield! mkArgUsage width aI
@@ -265,7 +265,7 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
         | helpflag :: _ ->
             yield Environment.NewLine
             let wrappedList =
-                sprintf "Use '%s <subcommand> %s' for additional information." programName helpflag
+                String.Format(labels.SubcommandHelpHint, programName, helpflag)
                 |> wordwrapSafe width
 
             for line in wrappedList do
@@ -276,7 +276,7 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
     if options.Length > 0 || argInfo.UsesHelpParam then
         let! length = StringExpr.currentLength
         if length > 0 then yield Environment.NewLine
-        yield "OPTIONS:"
+        yield labels.Options
         yield Environment.NewLine; yield Environment.NewLine
 
         for aI in options do yield! mkArgUsage width aI
@@ -284,6 +284,10 @@ let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax wid
 
         yield! mkHelpParamUsage width argInfo.HelpParam
 }
+
+/// Back-compat wrapper: renders with <c>UsageStrings.Default</c> (English).
+let mkUsageString (argInfo : UnionArgInfo) (programName : string) hideSyntax width (message : string option) =
+    mkUsageStringWithLabels argInfo programName hideSyntax width UsageStrings.Default message
 
 /// <summary>
 ///     print a command line argument for a set of parameters

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -265,7 +265,7 @@ let mkUsageStringWithLabels (argInfo : UnionArgInfo) (programName : string) hide
         | helpflag :: _ ->
             yield Environment.NewLine
             let wrappedList =
-                String.Format(labels.SubcommandHelpHint, programName, helpflag)
+                String.Format(labels.SubcommandHelpHintFormat, programName, helpflag)
                 |> wordwrapSafe width
 
             for line in wrappedList do

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Tests.fs"/>
     <Compile Include="CoverageTests.fs"/>
     <Compile Include="ParseConfigTests.fs"/>
+    <Compile Include="UsageStringsTests.fs"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>

--- a/tests/Argu.Tests/CoverageTests.fs
+++ b/tests/Argu.Tests/CoverageTests.fs
@@ -34,7 +34,7 @@ type SimpleArgs =
 
 [<Fact>]
 let ``ErrorCode.CommandLine: unrecognized argument message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
+    let parser = ArgumentParser.Create<SimpleArgs>()
     match Helpers.parserError parser [| "--bogus" |] with
     | None -> failwith "expected parse error"
     | Some (code, msg) ->
@@ -43,7 +43,7 @@ let ``ErrorCode.CommandLine: unrecognized argument message`` () =
 
 [<Fact>]
 let ``ErrorCode.PostProcess: missing mandatory message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
+    let parser = ArgumentParser.Create<SimpleArgs>()
     match Helpers.parserError parser [||] with
     | None -> failwith "expected parse error"
     | Some (code, msg) ->
@@ -52,7 +52,7 @@ let ``ErrorCode.PostProcess: missing mandatory message`` () =
 
 [<Fact>]
 let ``ErrorCode.CommandLine: missing argument value message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
+    let parser = ArgumentParser.Create<SimpleArgs>()
     match Helpers.parserError parser [| "--port" |] with
     | None -> failwith "expected parse error"
     | Some (code, msg) ->
@@ -85,7 +85,7 @@ type Level1Args =
 
 [<Fact>]
 let ``Deep subcommand: mandatory at level 3 missing surfaces in error`` () =
-    let parser = ArgumentParser.Create<Level1Args>(programName = "app")
+    let parser = ArgumentParser.Create<Level1Args>()
     match Helpers.parserError parser [| "level2"; "level3" |] with
     | None -> failwith "expected parse error"
     | Some (code, msg) ->
@@ -95,7 +95,7 @@ let ``Deep subcommand: mandatory at level 3 missing surfaces in error`` () =
 
 [<Fact>]
 let ``Deep subcommand: providing the leaf mandatory parses cleanly`` () =
-    let parser = ArgumentParser.Create<Level1Args>(programName = "app")
+    let parser = ArgumentParser.Create<Level1Args>()
     let results = parser.ParseCommandLine([| "level2"; "level3"; "--inner"; "ok" |], raiseOnUsage = false)
     // Probe through the public surface: walk subcommand → subcommand → leaf.
     let l2 = results.GetResult(Level2)
@@ -118,7 +118,7 @@ type AppSettingsArgs =
 
 [<Fact>]
 let ``AppSettings: dictionary reader returns parsed value`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let dict = Dictionary<string, string>()
     dict["required-key"] <- "hello"
     dict["int-key"] <- "42"
@@ -129,7 +129,7 @@ let ``AppSettings: dictionary reader returns parsed value`` () =
 
 [<Fact>]
 let ``AppSettings: missing mandatory key raises`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let dict = Dictionary<string, string>()
     // required-key intentionally absent
     let reader = ConfigurationReader.FromDictionary dict
@@ -146,7 +146,7 @@ let ``AppSettings: missing mandatory key raises`` () =
 
 [<Fact>]
 let ``AppSettings: null or empty value is treated as absent`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let dict = Dictionary<string, string>()
     dict["required-key"] <- "x" // satisfy mandatory
     dict["optional-key"] <- ""   // empty string should be treated as absent
@@ -156,7 +156,7 @@ let ``AppSettings: null or empty value is treated as absent`` () =
 
 [<Fact>]
 let ``AppSettings: invalid type-parse raises with key in message`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let dict = Dictionary<string, string>()
     dict["required-key"] <- "x"
     dict["int-key"] <- "not-a-number"
@@ -172,7 +172,7 @@ let ``AppSettings: invalid type-parse raises with key in message`` () =
 
 [<Fact>]
 let ``AppSettings: ignoreMissing=true skips mandatory check`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let reader = ConfigurationReader.FromDictionary(Dictionary<string, string>())
     // Should not raise.
     let results = parser.ParseConfiguration(reader, ignoreMissing = true)
@@ -192,7 +192,7 @@ let ``EnvironmentVariableConfigurationReader: reads process env`` () =
     let prior = Environment.GetEnvironmentVariable key
     try
         Environment.SetEnvironmentVariable(key, "from-env")
-        let parser = ArgumentParser.Create<EnvArgs>(programName = "app")
+        let parser = ArgumentParser.Create<EnvArgs>()
         let reader = ConfigurationReader.FromEnvironmentVariables()
         let results = parser.ParseConfiguration(reader, ignoreMissing = true)
         test <@ results.GetResult(Val) = "from-env" @>

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -283,7 +283,7 @@ let ``CLIArguments Locale`` () =
     let originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture
     try
         System.Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo("tr-TR")
-        let parser2 = ArgumentParser.Create<LocaleTurkish> (programName = "gadget")
+        let parser2 = ArgumentParser.Create<LocaleTurkish>(programName = "gadget")
         let result = parser2.ParseCommandLine([| "--install"; "true" |], ignoreMissing = true)
         test <@ result.GetResult <@ Install @> @>
     finally

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -1,74 +1,72 @@
-namespace Argu.Tests
+/// Tests for the localizable UsageStrings record
+module Argu.Tests.UsageStrings
 
-open Xunit
 open Swensen.Unquote
+open Xunit
 
 open Argu
 
-/// Tests for the localisable UsageStrings record (PR 15).
-module ``Argu Tests UsageStrings`` =
+type SimpleArgs =
+    | [<Mandatory>] Port of int
+    | Verbose
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Port _ -> "port to bind to"
+            | Verbose -> "verbose output"
 
-    type SimpleArgs =
-        | [<Mandatory>] Port of int
-        | Verbose
-        interface IArgParserTemplate with
-            member this.Usage =
-                match this with
-                | Port _ -> "port to bind to"
-                | Verbose -> "verbose output"
+type WithSub =
+    | [<CliPrefix(CliPrefix.None)>] Run of ParseResults<SubArgs>
+    interface IArgParserTemplate with
+        member this.Usage = "subcommand"
+and SubArgs =
+    | [<Mandatory>] Inner of string
+    interface IArgParserTemplate with
+        member this.Usage = "leaf"
 
-    type SubArgs =
-        | [<Mandatory>] Inner of string
-        interface IArgParserTemplate with
-            member this.Usage = "leaf"
+[<Fact>]
+let ``UsageStrings.Default reproduces the historical English labels`` () =
+    let d = UsageStrings.Default
+    test <@ d.Usage = "USAGE: " @>
+    test <@ d.Options = "OPTIONS:" @>
+    test <@ d.Subcommands = "SUBCOMMANDS:" @>
+    test <@ d.SubcommandHelpHintFormat = "Use '{0} <subcommand> {1}' for additional information." @>
 
-    type WithSub =
-        | [<CliPrefix(CliPrefix.None)>] Run of ParseResults<SubArgs>
-        interface IArgParserTemplate with
-            member this.Usage = "subcommand"
+[<Fact>]
+let ``PrintUsage with no override emits English headers`` () =
+    let parser = ArgumentParser.Create<SimpleArgs>()
+    let rendered = parser.PrintUsage()
+    test <@ rendered.Contains "USAGE:" @>
+    test <@ rendered.Contains "OPTIONS:" @>
 
-    [<Fact>]
-    let ``UsageStrings.Default reproduces the historical English labels`` () =
-        let d = UsageStrings.Default
-        test <@ d.Usage = "USAGE: " @>
-        test <@ d.Options = "OPTIONS:" @>
-        test <@ d.Subcommands = "SUBCOMMANDS:" @>
-        test <@ d.SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information." @>
+[<Fact>]
+let ``PrintUsage with custom UsageStrings emits translated headers`` () =
+    let parser = ArgumentParser.Create<SimpleArgs>()
+    let labels =
+        { Usage = "UTILISATION : "
+          Options = "OPTIONS :"
+          Subcommands = "SOUS-COMMANDES :"
+          SubcommandHelpHintFormat = "Use '{0} <subcommand> {1}' for additional information." }
+    let rendered = parser.PrintUsage(usageStrings = labels)
+    test <@ rendered.Contains "UTILISATION : " @>
+    test <@ rendered.Contains "OPTIONS :" @>
+    // English labels must NOT appear when a custom set is provided.
+    test <@ not (rendered.Contains "USAGE:") @>
+    test <@ not (rendered.Contains "OPTIONS:") @>
 
-    [<Fact>]
-    let ``PrintUsage with no override emits English headers`` () =
-        let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
-        let rendered = parser.PrintUsage()
-        test <@ rendered.Contains "USAGE: " @>
-        test <@ rendered.Contains "OPTIONS:" @>
+[<Fact>]
+let ``SubcommandHelpHint placeholders are interpolated`` () =
+    let parser = ArgumentParser.Create<WithSub>(programName = "myapp")
+    // Default English render mentions the program and help flag verbatim.
+    let rendered = parser.PrintUsage()
+    test <@ rendered.Contains "Use 'myapp <subcommand> --help'" @>
 
-    [<Fact>]
-    let ``PrintUsage with custom UsageStrings emits translated headers`` () =
-        let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
-        let labels =
-            { Usage = "UTILISATION : "
-              Options = "OPTIONS :"
-              Subcommands = "SOUS-COMMANDES :"
-              SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information." }
-        let rendered = parser.PrintUsage(usageStrings = labels)
-        test <@ rendered.Contains "UTILISATION : " @>
-        test <@ rendered.Contains "OPTIONS :" @>
-        // English labels must NOT appear when a custom set is provided.
-        test <@ not (rendered.Contains "USAGE: ") @>
-        test <@ not (rendered.Contains "OPTIONS:\r") @> // CRLF-anchored so it isn't matched by 'OPTIONS :'
-
-    [<Fact>]
-    let ``SubcommandHelpHint placeholders are interpolated`` () =
-        let parser = ArgumentParser.Create<WithSub>(programName = "myapp")
-        // Default English render mentions the program and help flag verbatim.
-        let rendered = parser.PrintUsage()
-        test <@ rendered.Contains "Use 'myapp <subcommand> --help'" @>
-
-    [<Fact>]
-    let ``Custom SubcommandHelpHint replaces the default hint line`` () =
-        let parser = ArgumentParser.Create<WithSub>(programName = "myapp")
-        let labels =
-            { UsageStrings.Default with
-                SubcommandHelpHint = "Tapez '{0} <sous-commande> {1}' pour plus d'informations." }
-        let rendered = parser.PrintUsage(usageStrings = labels)
-        test <@ rendered.Contains "Tapez 'myapp <sous-commande> --help' pour plus d'informations." @>
+[<Fact>]
+let ``Custom SubcommandHelpHint replaces the default hint line`` () =
+    let parser = ArgumentParser.Create<WithSub>(programName = "myapp",
+                                                (* Inhibit environment-induced wrapping*) usageStringCharacterWidth = 100)
+    let labels =
+        { UsageStrings.Default with
+            SubcommandHelpHintFormat = "Tapez '{0} <sous-commande> {1}' pour plus d'informations." }
+    let rendered = parser.PrintUsage(usageStrings = labels)
+    test <@ rendered.Contains "Tapez 'myapp <sous-commande> --help' pour plus d'informations." @>

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -1,0 +1,74 @@
+namespace Argu.Tests
+
+open Xunit
+open Swensen.Unquote
+
+open Argu
+
+/// Tests for the localisable UsageStrings record (PR 15).
+module ``Argu Tests UsageStrings`` =
+
+    type SimpleArgs =
+        | [<Mandatory>] Port of int
+        | Verbose
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Port _ -> "port to bind to"
+                | Verbose -> "verbose output"
+
+    type SubArgs =
+        | [<Mandatory>] Inner of string
+        interface IArgParserTemplate with
+            member this.Usage = "leaf"
+
+    type WithSub =
+        | [<CliPrefix(CliPrefix.None)>] Run of ParseResults<SubArgs>
+        interface IArgParserTemplate with
+            member this.Usage = "subcommand"
+
+    [<Fact>]
+    let ``UsageStrings.Default reproduces the historical English labels`` () =
+        let d = UsageStrings.Default
+        test <@ d.Usage = "USAGE: " @>
+        test <@ d.Options = "OPTIONS:" @>
+        test <@ d.Subcommands = "SUBCOMMANDS:" @>
+        test <@ d.SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information." @>
+
+    [<Fact>]
+    let ``PrintUsage with no override emits English headers`` () =
+        let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
+        let rendered = parser.PrintUsage()
+        test <@ rendered.Contains "USAGE: " @>
+        test <@ rendered.Contains "OPTIONS:" @>
+
+    [<Fact>]
+    let ``PrintUsage with custom UsageStrings emits translated headers`` () =
+        let parser = ArgumentParser.Create<SimpleArgs>(programName = "app")
+        let labels =
+            { Usage = "UTILISATION : "
+              Options = "OPTIONS :"
+              Subcommands = "SOUS-COMMANDES :"
+              SubcommandHelpHint = "Use '{0} <subcommand> {1}' for additional information." }
+        let rendered = parser.PrintUsage(usageStrings = labels)
+        test <@ rendered.Contains "UTILISATION : " @>
+        test <@ rendered.Contains "OPTIONS :" @>
+        // English labels must NOT appear when a custom set is provided.
+        test <@ not (rendered.Contains "USAGE: ") @>
+        test <@ not (rendered.Contains "OPTIONS:\r") @> // CRLF-anchored so it isn't matched by 'OPTIONS :'
+
+    [<Fact>]
+    let ``SubcommandHelpHint placeholders are interpolated`` () =
+        let parser = ArgumentParser.Create<WithSub>(programName = "myapp")
+        // Default English render mentions the program and help flag verbatim.
+        let rendered = parser.PrintUsage()
+        test <@ rendered.Contains "Use 'myapp <subcommand> --help'" @>
+
+    [<Fact>]
+    let ``Custom SubcommandHelpHint replaces the default hint line`` () =
+        let parser = ArgumentParser.Create<WithSub>(programName = "myapp")
+        let labels =
+            { UsageStrings.Default with
+                SubcommandHelpHint = "Tapez '{0} <sous-commande> {1}' pour plus d'informations." }
+        let rendered = parser.PrintUsage(usageStrings = labels)
+        test <@ rendered.Contains "Tapez 'myapp <sous-commande> --help' pour plus d'informations." @>


### PR DESCRIPTION
feat(UsageStrings): Add localisable labels record for usage rendering

* Types.fs: New public UsageStrings record carrying Usage, Options,
  Subcommands and SubcommandHelpHint. UsageStrings.Default returns the
  historical English labels.
* UnParsers.fs: New mkUsageStringWithLabels that threads a UsageStrings
  through the renderer. Old mkUsageString kept as a thin forwarder using
  UsageStrings.Default, so all existing internal call sites are
  byte-identical.
* ArgumentParser.fs: PrintUsage gains an optional ?usageStrings parameter
  defaulting to UsageStrings.Default. Existing signatures unchanged for
  positional callers (the new parameter is optional and appended last).

Additive only. The four hard-coded English labels are still emitted when
no UsageStrings is passed, preserving every existing rendered byte.

---

test(UsageStrings): Add coverage for localisation hooks

5 new tests:
* UsageStrings.Default returns the historical English labels verbatim.
* PrintUsage() with no override emits the English headers.
* PrintUsage(usageStrings = french) emits the French headers and never
  the English ones.
* SubcommandHelpHint default placeholder {0} / {1} interpolation is
  applied so the rendered hint shows 'myapp <subcommand> --help'.
* A fully custom SubcommandHelpHint replaces the default hint line.

Net suite size on this branch: 112 -> 117.

---