### PR TITLE
docs: Add XML summary on previously-undocumented public members

### DIFF
--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -244,6 +244,7 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
         writer.ToString()
 
 
+    /// Accepts an <see cref="IArgumentParserVisitor`1"/> so callers can recover the typed parser from the untyped base.
     override self.Accept visitor = visitor.Visit self
 
 /// Rank-2 function used for accessing typed APIs of untyped parsers

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -61,6 +61,7 @@ type NoAppSettingsAttribute () = inherit Attribute ()
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
 type HelpFlagsAttribute ([<ParamArray>] names : string []) =
     inherit Attribute()
+    /// CLI switches that trigger help text rendering.
     member _.Names = names
 
 /// Specifies that Help/Usage switches should be disabled for the CLI.
@@ -71,12 +72,14 @@ type DisableHelpFlagsAttribute () = inherit HelpFlagsAttribute ()
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
 type HelpDescriptionAttribute (description : string) =
     inherit Attribute()
+    /// The custom description rendered next to the help switches in the usage string.
     member _.Description = description
 
 /// Declares that argument should be placed at specific position.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CliPositionAttribute(position : CliPosition) =
     inherit Attribute()
+    /// The mandated CLI position (First, Last, or Unspecified).
     member _.Position = position
 
 /// Declares that argument can only be placed at the beginning of the CLI syntax.
@@ -102,6 +105,7 @@ type SubCommandAttribute () = inherit Attribute()
 type MainCommandAttribute (argumentName : string) =
     inherit Attribute()
     new () = MainCommandAttribute(null)
+    /// Optional label used in the rendered usage string. <c>null</c> means use the auto-generated name.
     member _.ArgumentName = argumentName
 
 /// Print F# 3.1 field labels in usage string. OBSOLETE
@@ -116,6 +120,7 @@ type PrintLabelsAttribute () = inherit Attribute ()
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAssignmentAttribute (separator : string) =
     inherit Attribute ()
+    /// The assignment separator string (e.g. "=" or ":").
     member _.Separator = separator
 
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
@@ -138,6 +143,7 @@ type ColonAssignmentAttribute () =
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAssignmentOrSpacedAttribute (separator : string) =
     inherit Attribute ()
+    /// The assignment separator string (e.g. "=" or ":"). Spaced form is also accepted.
     member _.Separator = separator
 
 /// Use '--param=arg' assignment syntax in CLI.
@@ -159,7 +165,9 @@ type ColonAssignmentOrSpacedAttribute () =
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string []) =
     inherit Attribute ()
+    /// The primary CLI identifier, replacing the auto-generated name.
     member _.Name = name
+    /// Additional alias names accepted on the CLI alongside <see cref="Name"/>.
     member _.AltNames = altNames
 
 /// Declares a set of secondary CLI identifiers for the current parameter.
@@ -168,6 +176,7 @@ type CustomCommandLineAttribute (name : string, [<ParamArray>]altNames : string 
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = true)>]
 type AltCommandLineAttribute ([<ParamArray>] names : string []) =
     inherit Attribute ()
+    /// Secondary CLI identifiers accepted alongside the primary name.
     member _.Names = names
 
 /// Declares a custom key identifier for the current parameter in AppSettings parsing.
@@ -175,6 +184,7 @@ type AltCommandLineAttribute ([<ParamArray>] names : string []) =
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type CustomAppSettingsAttribute (name : string) =
     inherit Attribute ()
+    /// The AppSettings key identifier, replacing the auto-generated name.
     member _.Name = name
 
 /// Specify a custom value separator in AppSettings parsing parameters.
@@ -183,7 +193,9 @@ type CustomAppSettingsAttribute (name : string) =
 type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], splitOptions : StringSplitOptions) =
     inherit Attribute()
     new (separator : char) = AppSettingsSeparatorAttribute([|string separator|], StringSplitOptions.None)
+    /// The separator strings used to split AppSettings list/CSV values.
     member _.Separators = separators
+    /// Split options applied during AppSettings list/CSV value separation.
     member _.SplitOptions = splitOptions
 
 /// Specifies a custom prefix for auto-generated CLI names.
@@ -191,4 +203,5 @@ type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], split
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Class, AllowMultiple = false)>]
 type CliPrefixAttribute(prefix : string) =
     inherit Attribute()
+    /// The auto-generation prefix (e.g. "--", "-", or empty).
     member _.Prefix = prefix

--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -47,9 +47,12 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         |> Seq.toList
 
     interface IParseResult with
+        /// Returns all parse results as <c>obj</c>, for callers that do not know the template type.
         member x.GetAllResults () = x.GetAllResults() |> Seq.map box
 
+    /// The <see cref="IExiter"/> used to surface parse and post-process errors.
     member _.ErrorHandler = exiter
+    /// The program name used when rendering usage messages.
     member _.ProgramName = programName
     member internal _.Description = description
     member internal _.ArgInfo = argInfo
@@ -299,6 +302,7 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         | Some sc -> sc
         | None -> error false ErrorCode.PostProcess "no valid subcommand has been specified."
 
+    /// Renders the parse results as a debug-friendly string via F#'s structured formatter.
     override r.ToString() = sprintf "%A" (r.GetAllResults())
 
     // used by StructuredFormatDisplay attribute

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -47,6 +47,7 @@ type ArguException internal (message : string, exn : Exception) =
 /// Parse exception raised by Argu
 type ArguParseException internal (message : string, errorCode : ErrorCode) =
     inherit ArguException(message)
+    /// The <see cref="ErrorCode"/> categorising this parse failure.
     member _.ErrorCode = errorCode
 
 /// An interface for error handling in the argument parser
@@ -102,7 +103,9 @@ type ArgumentType =
 /// Describes the permitted separators between arguments and their values
 type CustomAssignmentSeparator =
     {
+        /// The separator string between the parameter name and its value (e.g. "=" or ":").
         Separator : string
+        /// When <c>true</c>, the spaced form (<c>--param value</c>) is also accepted alongside the separator form.
         TolerateSpacedArguments : bool
     }
 


### PR DESCRIPTION
docs: Add XML summary on previously-undocumented public members

Covers the public surface gaps:
* ParseResults: ErrorHandler, ProgramName, ToString override and the
  IParseResult.GetAllResults interface method.
* ArgumentParser: the abstract base's Accept override.
* Attributes: property docs on HelpFlagsAttribute.Names,
  HelpDescriptionAttribute.Description, CliPositionAttribute.Position,
  MainCommandAttribute.ArgumentName, CustomAssignment*.Separator,
  CustomCommandLineAttribute.{Name, AltNames}, AltCommandLineAttribute.Names,
  CustomAppSettingsAttribute.Name, AppSettingsSeparatorAttribute.Separators
  / SplitOptions, and CliPrefixAttribute.Prefix.
* Types: ArguParseException.ErrorCode and CustomAssignmentSeparator's
  field-level docs.

Pure docs change; zero functional or signature impact.

---