### PR TITLE
feat(Nullable): Enable F# nullable reference types on Argu.fsproj

### DIFF
--- a/src/Argu/Argu.fsproj
+++ b/src/Argu/Argu.fsproj
@@ -4,6 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <PackageIcon>logo.png</PackageIcon>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.fs"/>

--- a/src/Argu/ConfigReaders.fs
+++ b/src/Argu/ConfigReaders.fs
@@ -11,7 +11,7 @@ type IConfigurationReader =
     /// Configuration reader identifier
     abstract Name : string
     /// Gets value corresponding to supplied key
-    abstract GetValue : key:string -> string
+    abstract GetValue : key:string -> string | null
 
 /// Configuration reader that never returns a value
 type NullConfigurationReader() =
@@ -22,7 +22,7 @@ type NullConfigurationReader() =
 /// Environment variable-based configuration reader
 type EnvironmentVariableConfigurationReader() =
     // order of environment variable target lookup
-    let targets = 
+    let targets =
         [| EnvironmentVariableTarget.Process
            EnvironmentVariableTarget.User
            EnvironmentVariableTarget.Machine |]

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -40,7 +40,7 @@ type CliPosition =
     | Last          = 3
 
 /// Exception raised by Argu
-type ArguException internal (message : string, exn : Exception) =
+type ArguException internal (message : string, exn : Exception | null) =
     inherit Exception(message, exn)
     internal new(message) = ArguException(message, null)
 


### PR DESCRIPTION
feat(Nullable): Enable F# nullable reference types on Argu.fsproj

* Argu.fsproj: <Nullable>enable</Nullable>.
* Types.fs: ArguException.ctor inner-exception parameter is now
  'Exception | null', accurately reflecting that callers (including
  the convenience single-arg constructor on line 45) may pass null.
  The visible signature already accepted null at runtime; this just
  annotates it.

Compile-time hints only. No runtime behaviour change. All 112 tests
pass unchanged.

---