### PR TITLE
feat(ParseConfig): Add record + Parse(config) overload (additive)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,9 @@
 * Fix NRE in derivation of programName introduced in 6.2.2 [#292](https://github.com/SwensenSoftware/unquote/pull/292) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Clarify exception in expr2Uci [#293](https://github.com/SwensenSoftware/unquote/pull/293) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Report all missing args in error message, not just first level [#297](https://github.com/SwensenSoftware/unquote/pull/297) [@dimension-zero](https://github.com/dimension-zero)
-* Add `Argu.Samples.Introspect` sample [#298](https://github.com/SwensenSoftware/unquote/pull/298) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Limit min wordwrap column to 20 [#302](https://github.com/SwensenSoftware/unquote/pull/302) [@dimension-zero](https://github.com/dimension-zero)
+* Add `Argu.Samples.Introspect` sample [#298](https://github.com/SwensenSoftware/unquote/pull/298) [@dimension-zero](https://github.com/dimension-zero)
+* Add `ArgumentParser.Parse(ParseConfig)` [#307](https://github.com/SwensenSoftware/unquote/pull/307) [@dimension-zero](https://github.com/dimension-zero)
 
 ### 6.2.5
 * Drop Package `FSharp.Core` dependency to `6.0.0` [#264](https://github.com/fsprojects/Argu/pull/264)

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -25,13 +25,12 @@ type ParseConfig =
     /// Default parse configuration, matching the historical <c>Parse(...)</c> defaults:
     /// inputs and configurationReader inherited from the environment, do not ignore
     /// missing or unrecognized arguments, and raise on '--help'.
-    static member Default : ParseConfig = {
-        Inputs = None
-        ConfigurationReader = None
-        IgnoreMissing = false
-        IgnoreUnrecognized = false
-        RaiseOnUsage = true
-    }
+    static member Default : ParseConfig =
+        {   Inputs = None
+            ConfigurationReader = None
+            IgnoreMissing = false
+            IgnoreUnrecognized = false
+            RaiseOnUsage = true }
 
 /// The Argu type generates an argument parser given a type argument
 /// that is an F# discriminated union. It can then be used to parse command line arguments
@@ -191,8 +190,8 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
     ///          the parameter set programmatically (e.g. layering host defaults over user
     ///          overrides) without juggling many optional method arguments.</summary>
     /// <param name="config">The parse configuration. See <c>ParseConfig.Default</c>.</param>
-    member ap.Parse (config : ParseConfig) : ParseResults<'Template> =
-        ap.Parse(
+    member self.Parse (config : ParseConfig) : ParseResults<'Template> =
+        self.Parse(
             ?inputs = config.Inputs,
             ?configurationReader = config.ConfigurationReader,
             ignoreMissing = config.IgnoreMissing,
@@ -272,8 +271,8 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
         mkCommandLineArgs argInfo (Seq.cast args) |> Seq.toArray
 
     /// <summary>Prints parameters in command line format. Useful for argument string generation.</summary>
-    member ap.PrintCommandLineArgumentsFlat (args : 'Template list) : string =
-        ap.PrintCommandLineArguments args |> flattenCliTokens
+    member self.PrintCommandLineArgumentsFlat (args : 'Template list) : string =
+        self.PrintCommandLineArguments args |> flattenCliTokens
 
     /// <summary>Prints parameters in App.Config format.</summary>
     /// <param name="args">The parameters that fill out the XML document.</param>

--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -3,6 +3,36 @@
 open FSharp.Quotations
 open Argu.UnionArgInfo
 
+/// Configuration record for <see cref="ArgumentParser`1.Parse(ParseConfig)"/>.
+/// Each field carries the same meaning as the matching optional parameter on
+/// the existing <c>Parse</c> overload. Use <see cref="ParseConfig.Default"/>
+/// as a starting point and override only the fields you care about.
+[<NoEquality; NoComparison>]
+type ParseConfig =
+    {
+        /// The command line input. <c>None</c> takes the inputs from <c>System.Environment</c>.
+        Inputs : string [] option
+        /// Configuration reader used to source AppSettings-style arguments.
+        /// <c>None</c> uses the AppSettings configuration of the current process.
+        ConfigurationReader : IConfigurationReader option
+        /// Ignore errors caused by the Mandatory attribute.
+        IgnoreMissing : bool
+        /// Ignore CLI arguments that do not match the schema.
+        IgnoreUnrecognized : bool
+        /// Treat '--help' parameters as parse errors.
+        RaiseOnUsage : bool
+    }
+    /// Default parse configuration, matching the historical <c>Parse(...)</c> defaults:
+    /// inputs and configurationReader inherited from the environment, do not ignore
+    /// missing or unrecognized arguments, and raise on '--help'.
+    static member Default : ParseConfig = {
+        Inputs = None
+        ConfigurationReader = None
+        IgnoreMissing = false
+        IgnoreUnrecognized = false
+        RaiseOnUsage = true
+    }
+
 /// The Argu type generates an argument parser given a type argument
 /// that is an F# discriminated union. It can then be used to parse command line arguments
 /// or XML configuration.
@@ -155,6 +185,19 @@ and [<Sealed; NoEquality; NoComparison; AutoSerializable(false)>]
             new ParseResults<'Template>(argInfo, results, _programName, helpTextMessage, _usageStringCharacterWidth, errorHandler)
 
         with ParserExn (errorCode, msg) -> errorHandler.Exit (msg, errorCode)
+
+    /// <summary>Parse both command line args and supplied configuration reader, using
+    ///          a <see cref="ParseConfig"/> record. Useful when callers want to construct
+    ///          the parameter set programmatically (e.g. layering host defaults over user
+    ///          overrides) without juggling many optional method arguments.</summary>
+    /// <param name="config">The parse configuration. See <c>ParseConfig.Default</c>.</param>
+    member ap.Parse (config : ParseConfig) : ParseResults<'Template> =
+        ap.Parse(
+            ?inputs = config.Inputs,
+            ?configurationReader = config.ConfigurationReader,
+            ignoreMissing = config.IgnoreMissing,
+            ignoreUnrecognized = config.IgnoreUnrecognized,
+            raiseOnUsage = config.RaiseOnUsage)
 
     /// <summary>Parse both command line args and supplied configuration reader.
     ///          Results are merged with command line args overriding configuration parameters.</summary>

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -7,6 +7,7 @@
     <Compile Include="PrimitiveTests.fs" />
     <Compile Include="Tests.fs"/>
     <Compile Include="CoverageTests.fs"/>
+    <Compile Include="ParseConfigTests.fs"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>

--- a/tests/Argu.Tests/ParseConfigTests.fs
+++ b/tests/Argu.Tests/ParseConfigTests.fs
@@ -1,0 +1,91 @@
+namespace Argu.Tests
+
+open System.Collections.Generic
+open Xunit
+open Swensen.Unquote
+
+open Argu
+
+/// Tests for the ParseConfig record + Parse(config) overload (PR 19).
+module ``Argu Tests ParseConfig`` =
+
+    type Args =
+        | [<Mandatory>] Port of int
+        | Verbose
+        | Tag of string
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Port _ -> "port"
+                | Verbose -> "verbose"
+                | Tag _ -> "tag"
+
+    let private parser () = ArgumentParser.Create<Args>(programName = "app")
+
+    [<Fact>]
+    let ``ParseConfig.Default holds historical defaults`` () =
+        let d = ParseConfig.Default
+        test <@ d.Inputs = None @>
+        test <@ d.ConfigurationReader = None @>
+        test <@ d.IgnoreMissing = false @>
+        test <@ d.IgnoreUnrecognized = false @>
+        test <@ d.RaiseOnUsage = true @>
+
+    [<Fact>]
+    let ``Parse(config with explicit inputs) parses those inputs`` () =
+        let p = parser ()
+        let argv = [| "--port"; "8080"; "--verbose" |]
+        let cfg = { ParseConfig.Default with Inputs = Some argv ; RaiseOnUsage = false }
+        let results = p.Parse(cfg)
+        test <@ results.GetResult(Port) = 8080 @>
+        test <@ results.Contains(Verbose) @>
+
+    [<Fact>]
+    let ``Parse(config) matches Parse(?inputs, ...) for the same parameters`` () =
+        let p = parser ()
+        let argv = [| "--port"; "1234"; "--tag"; "v1" |]
+        let viaConfig =
+            let cfg = { ParseConfig.Default with Inputs = Some argv ; RaiseOnUsage = false }
+            p.Parse(cfg)
+        let viaOptional = p.Parse(inputs = argv, raiseOnUsage = false)
+        test <@ viaConfig.GetResult(Port) = viaOptional.GetResult(Port) @>
+        test <@ viaConfig.GetResult(Tag) = viaOptional.GetResult(Tag) @>
+
+    [<Fact>]
+    let ``Parse(config with IgnoreMissing=true) skips mandatory check`` () =
+        let p = parser ()
+        let cfg = { ParseConfig.Default with Inputs = Some [||] ; IgnoreMissing = true }
+        let results = p.Parse(cfg)
+        test <@ results.TryGetResult(Port) = None @>
+
+    [<Fact>]
+    let ``Parse(config with IgnoreUnrecognized=true) collects unknown args`` () =
+        let p = parser ()
+        let cfg =
+            { ParseConfig.Default with
+                Inputs = Some [| "--port"; "1"; "--bogus" |]
+                IgnoreUnrecognized = true
+                RaiseOnUsage = false }
+        let results = p.Parse(cfg)
+        test <@ results.UnrecognizedCliParams |> List.contains "--bogus" @>
+
+    /// Argu's missing-mandatory check fires from the CLI even when
+    /// AppSettings provides a value (pre-existing behaviour, unrelated
+    /// to PR 19), so the AppSettings round-trip test uses a
+    /// non-mandatory schema.
+    type AppSettingsArgs =
+        | TagKey of string
+        interface IArgParserTemplate with member this.Usage = "tag"
+
+    [<Fact>]
+    let ``Parse(config with ConfigurationReader) sources AppSettings`` () =
+        let p = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
+        let dict = Dictionary<string, string>()
+        dict["tagkey"] <- "v1"
+        let reader = ConfigurationReader.FromDictionary dict
+        let cfg =
+            { ParseConfig.Default with
+                Inputs = Some [||]
+                ConfigurationReader = Some reader }
+        let results = p.Parse(cfg)
+        test <@ results.GetResult(TagKey) = "v1" @>

--- a/tests/Argu.Tests/ParseConfigTests.fs
+++ b/tests/Argu.Tests/ParseConfigTests.fs
@@ -1,91 +1,85 @@
-namespace Argu.Tests
+module Argu.Tests.ParseConfigTests
 
 open System.Collections.Generic
-open Xunit
 open Swensen.Unquote
+open Xunit
 
 open Argu
 
-/// Tests for the ParseConfig record + Parse(config) overload (PR 19).
-module ``Argu Tests ParseConfig`` =
+type Args =
+    | [<Mandatory>] Port of int
+    | Verbose
+    | Tag of string
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Port _ -> "port"
+            | Verbose -> "verbose"
+            | Tag _ -> "tag"
 
-    type Args =
-        | [<Mandatory>] Port of int
-        | Verbose
-        | Tag of string
-        interface IArgParserTemplate with
-            member this.Usage =
-                match this with
-                | Port _ -> "port"
-                | Verbose -> "verbose"
-                | Tag _ -> "tag"
+let private parser () = ArgumentParser.Create<Args>()
+[<Fact>]
+let ``ParseConfig.Default holds historical defaults`` () =
+    let d = ParseConfig.Default
+    test <@ d.Inputs = None @>
+    test <@ d.ConfigurationReader = None @>
+    test <@ d.IgnoreMissing = false @>
+    test <@ d.IgnoreUnrecognized = false @>
+    test <@ d.RaiseOnUsage = true @>
 
-    let private parser () = ArgumentParser.Create<Args>(programName = "app")
+[<Fact>]
+let ``Parse(config with explicit inputs) parses those inputs`` () =
+    let p = parser ()
+    let argv = [| "--port"; "8080"; "--verbose" |]
+    let cfg = { ParseConfig.Default with Inputs = Some argv ; RaiseOnUsage = false }
+    let results = p.Parse(cfg)
+    test <@ results.GetResult(Port) = 8080 @>
+    test <@ results.Contains(Verbose) @>
 
-    [<Fact>]
-    let ``ParseConfig.Default holds historical defaults`` () =
-        let d = ParseConfig.Default
-        test <@ d.Inputs = None @>
-        test <@ d.ConfigurationReader = None @>
-        test <@ d.IgnoreMissing = false @>
-        test <@ d.IgnoreUnrecognized = false @>
-        test <@ d.RaiseOnUsage = true @>
-
-    [<Fact>]
-    let ``Parse(config with explicit inputs) parses those inputs`` () =
-        let p = parser ()
-        let argv = [| "--port"; "8080"; "--verbose" |]
+[<Fact>]
+let ``Parse(config) matches Parse(?inputs, ...) for the same parameters`` () =
+    let p = parser ()
+    let argv = [| "--port"; "1234"; "--tag"; "v1" |]
+    let viaConfig =
         let cfg = { ParseConfig.Default with Inputs = Some argv ; RaiseOnUsage = false }
-        let results = p.Parse(cfg)
-        test <@ results.GetResult(Port) = 8080 @>
-        test <@ results.Contains(Verbose) @>
+        p.Parse(cfg)
+    let viaOptional = p.Parse(inputs = argv, raiseOnUsage = false)
+    test <@ viaConfig.GetResult(Port) = viaOptional.GetResult(Port) @>
+    test <@ viaConfig.GetResult(Tag) = viaOptional.GetResult(Tag) @>
 
-    [<Fact>]
-    let ``Parse(config) matches Parse(?inputs, ...) for the same parameters`` () =
-        let p = parser ()
-        let argv = [| "--port"; "1234"; "--tag"; "v1" |]
-        let viaConfig =
-            let cfg = { ParseConfig.Default with Inputs = Some argv ; RaiseOnUsage = false }
-            p.Parse(cfg)
-        let viaOptional = p.Parse(inputs = argv, raiseOnUsage = false)
-        test <@ viaConfig.GetResult(Port) = viaOptional.GetResult(Port) @>
-        test <@ viaConfig.GetResult(Tag) = viaOptional.GetResult(Tag) @>
+[<Fact>]
+let ``Parse(config with IgnoreMissing=true) skips mandatory check`` () =
+    let p = parser ()
+    let cfg = { ParseConfig.Default with Inputs = Some [||] ; IgnoreMissing = true }
+    let results = p.Parse(cfg)
+    test <@ results.TryGetResult(Port) = None @>
 
-    [<Fact>]
-    let ``Parse(config with IgnoreMissing=true) skips mandatory check`` () =
-        let p = parser ()
-        let cfg = { ParseConfig.Default with Inputs = Some [||] ; IgnoreMissing = true }
-        let results = p.Parse(cfg)
-        test <@ results.TryGetResult(Port) = None @>
+[<Fact>]
+let ``Parse(config with IgnoreUnrecognized=true) collects unknown args`` () =
+    let p = parser ()
+    let cfg =
+        { ParseConfig.Default with
+            Inputs = Some [| "--port"; "1"; "--bogus" |]
+            IgnoreUnrecognized = true
+            RaiseOnUsage = false }
+    let results = p.Parse(cfg)
+    test <@ results.UnrecognizedCliParams |> List.contains "--bogus" @>
 
-    [<Fact>]
-    let ``Parse(config with IgnoreUnrecognized=true) collects unknown args`` () =
-        let p = parser ()
-        let cfg =
-            { ParseConfig.Default with
-                Inputs = Some [| "--port"; "1"; "--bogus" |]
-                IgnoreUnrecognized = true
-                RaiseOnUsage = false }
-        let results = p.Parse(cfg)
-        test <@ results.UnrecognizedCliParams |> List.contains "--bogus" @>
+/// Argu's missing-mandatory check fires from the CLI even when AppSettings provides a value (pre-existing behavior),
+/// so the AppSettings round-trip test uses a non-mandatory schema.
+type AppSettingsArgs =
+    | TagKey of string
+    interface IArgParserTemplate with member this.Usage = "tag"
 
-    /// Argu's missing-mandatory check fires from the CLI even when
-    /// AppSettings provides a value (pre-existing behaviour, unrelated
-    /// to PR 19), so the AppSettings round-trip test uses a
-    /// non-mandatory schema.
-    type AppSettingsArgs =
-        | TagKey of string
-        interface IArgParserTemplate with member this.Usage = "tag"
-
-    [<Fact>]
-    let ``Parse(config with ConfigurationReader) sources AppSettings`` () =
-        let p = ArgumentParser.Create<AppSettingsArgs>(programName = "app")
-        let dict = Dictionary<string, string>()
-        dict["tagkey"] <- "v1"
-        let reader = ConfigurationReader.FromDictionary dict
-        let cfg =
-            { ParseConfig.Default with
-                Inputs = Some [||]
-                ConfigurationReader = Some reader }
-        let results = p.Parse(cfg)
-        test <@ results.GetResult(TagKey) = "v1" @>
+[<Fact>]
+let ``Parse(config with ConfigurationReader) sources AppSettings`` () =
+    let p = ArgumentParser.Create<AppSettingsArgs>()
+    let dict = Dictionary<string, string>()
+    dict["tagkey"] <- "v1"
+    let reader = ConfigurationReader.FromDictionary dict
+    let cfg =
+        { ParseConfig.Default with
+            Inputs = Some [||]
+            ConfigurationReader = Some reader }
+    let results = p.Parse(cfg)
+    test <@ results.GetResult(TagKey) = "v1" @>


### PR DESCRIPTION
feat(ParseConfig): Add record + Parse(config) overload (additive)

* ArgumentParser.fs: Introduce public ParseConfig record carrying
  Inputs, ConfigurationReader, IgnoreMissing, IgnoreUnrecognized,
  RaiseOnUsage. Provide ParseConfig.Default reproducing the historical
  Parse(...) defaults.
* New Parse(config: ParseConfig) overload delegates to the existing
  Parse(?inputs, ?configurationReader, ...) implementation. All current
  overloads remain untouched, so existing callers see no shape change.

Useful when hosts want to layer configuration programmatically (e.g.
merging container-provided defaults with user overrides) rather than
juggling many optional method arguments.

---

test(ParseConfig): Add coverage for ParseConfig record + Parse(config)

6 new tests:
* ParseConfig.Default holds the historical defaults (None inputs, None
  reader, false IgnoreMissing/IgnoreUnrecognized, true RaiseOnUsage).
* Parse(config with explicit inputs) parses those inputs.
* Parse(config) matches Parse(?inputs, ...) for the same shape.
* IgnoreMissing=true skips the mandatory check on empty inputs.
* IgnoreUnrecognized=true gathers unknown args into UnrecognizedCliParams.
* ConfigurationReader provided via config sources AppSettings entries.

A separate non-mandatory schema is used for the AppSettings test because
Argu's missing-mandatory check fires from CLI parsing even when AppSettings
provides a value (existing behaviour, not introduced by PR 19).

Net suite size on this branch: 112 -> 118.

---