### PR TITLE
perf(UnionCaseArgInfo): Flatten Name / CommandLineNames / AppSettingsName

### DIFF
--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -40,9 +40,9 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         match results.Cases[id.Tag] |> Array.tryLast, flags with
         | None, _ ->
             let aI = argInfo.Cases.Value[id.Tag]
-            errorf (not aI.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." aI.Name.Value
+            errorf (not aI.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." aI.Name
         | Some r, Some flags when r |> filter flags |> not -> // A value is present, but the filter excludes it
-            errorf (not r.CaseInfo.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." r.CaseInfo.Name.Value
+            errorf (not r.CaseInfo.IsCommandLineArg) ErrorCode.PostProcess "ERROR: missing argument '%s'." r.CaseInfo.Name
         | Some r, _ -> r
 
     let parseResult (f : 'F -> 'S) (r : UnionCaseParseResult) =

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -102,7 +102,7 @@ type CliParseResultAggregator internal (argInfo : UnionArgInfo, stack : CliParse
         resultCount <- resultCount + 1
         let agg = results.Value[result.Tag]
         if result.CaseInfo.IsUnique && agg.Count > 0 then
-            error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name.Value
+            error argInfo ErrorCode.CommandLine "argument '%s' has been specified more than once." result.CaseInfo.Name
 
         if result.CaseInfo.ArgumentType = ArgumentType.SubCommand then
             if isSubCommandDefined then
@@ -228,10 +228,10 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                                 | _ -> error argInfo ErrorCode.CommandLine "parameter '%s' must be followed by <%s>, but was '%s'."
                                                     state.Reader.CurrentSegment p.Description token
 
-                            if success then   
+                            if success then
                                 // Might be a MainCommand, but if the main type is string, then might not
                                 // If we're ignoring unrecognized, then it's better to parse as unrecognized than an out-of-position MainCommand
-                                if mcp.IsLast && state.IgnoreUnrecognizedArgs && not state.Reader.IsCompleted then 
+                                if mcp.IsLast && state.IgnoreUnrecognizedArgs && not state.Reader.IsCompleted then
                                     aggregator.AppendUnrecognized tok
                                 else
                                     tokens.Add tok ; fields.Add result
@@ -249,7 +249,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
                     do aux 0
                     if fields.Count = parsers.Length then
-                        aggregator.AppendResult mcp mcp.Name.Value (fields.ToArray())
+                        aggregator.AppendResult mcp mcp.Name (fields.ToArray())
                         true
                     else
                         match argInfo.UnrecognizedGatherParam.Value with
@@ -284,18 +284,18 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
                                     | None -> error argInfo ErrorCode.CommandLine "unrecognized argument: '%s'." token
                                     args
                                 else args
-                            | CliParam _ -> 
-                                // If the main type is string, then the gathered arguments here might not be main commands. 
+                            | CliParam _ ->
+                                // If the main type is string, then the gathered arguments here might not be main commands.
                                 // Can detect this by observing a subsequent argument that IS recognized
-                                if mcp.IsLast && state.IgnoreUnrecognizedArgs 
-                                then List.iter aggregator.AppendUnrecognized args; [] 
+                                if mcp.IsLast && state.IgnoreUnrecognizedArgs
+                                then List.iter aggregator.AppendUnrecognized args; []
                                 else args
                             | _ -> args
 
-                        let gathered = gather true [] |> List.rev                        
+                        let gathered = gather true [] |> List.rev
                         match gathered with
                         | [] -> () ; false
-                        | list -> aggregator.AppendResult mcp mcp.Name.Value [| List.map (fun arg -> field.Parser arg  :?> 'T) list |] ; true }
+                        | list -> aggregator.AppendResult mcp mcp.Name [| List.map (fun arg -> field.Parser arg  :?> 'T) list |] ; true }
 
             | paramInfo -> arguExn "internal error. MainCommand has param representation %A" paramInfo
 
@@ -336,7 +336,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
         let parseSingleParameter fields =
             let fields = fields |> Array.map parseNextField
             aggregator.AppendResult caseInfo name fields
-        
+
         match caseInfo.ParameterInfo.Value with
         | Primitives [|field|] when caseInfo.IsCustomAssignment ->
             match assignment with
@@ -370,14 +370,14 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
 
                 | NoAssignment ->
                     error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'."
-                        caseInfo.Name.Value kf.Description caseInfo.CustomAssignmentSeparator.Value.Value.Separator vf.Description
+                        caseInfo.Name kf.Description caseInfo.CustomAssignmentSeparator.Value.Value.Separator vf.Description
 
             | CliParam(token,name,_,Assignment _) ->
                 error argInfo ErrorCode.CommandLine "argument '%s' was given invalid key name '%s' in '%s'."
                     state.Reader.CurrentSegment name token
             | _ ->
                 error argInfo ErrorCode.CommandLine "argument '%s' must be followed by assignment '%s%s%s'."
-                    caseInfo.Name.Value kf.Description caseInfo.CustomAssignmentSeparator.Value.Value.Separator vf.Description
+                    caseInfo.Name kf.Description caseInfo.CustomAssignmentSeparator.Value.Value.Separator vf.Description
 
         | Primitives fields ->
             parseSingleParameter fields

--- a/src/Argu/Parsers/Common.fs
+++ b/src/Argu/Parsers/Common.fs
@@ -33,7 +33,7 @@ let mkParseResultFromValues (info : UnionArgInfo) (exiter : IExiter) (width : in
         let tag = info.TagReader.Value value
         let case = info.Cases.Value[tag]
         let fields = case.FieldReader.Value value
-        let result = mkUnionCase case i ParseSource.None case.Name.Value fields
+        let result = mkUnionCase case i ParseSource.None case.Name fields
         agg[tag].Add result
         i <- i + 1
 
@@ -73,12 +73,12 @@ let postProcessResults (argInfo : UnionArgInfo) (ignoreMissingMandatory : bool)
         | _, Some { MissingMandatoryCases = (firstCaseArgInfo, _) :: _ as allGroups } when not ignoreMissingMandatory  ->
             // NOTE also need to convey missing child / trailing args, not just flag first problem
             let allMissingParamNames =
-                seq { for _, missing in allGroups do for m in missing -> m.Name.Value }
+                seq { for _, missing in allGroups do for m in missing -> m.Name }
                 |> String.concat "', '"
             error firstCaseArgInfo ErrorCode.PostProcess "missing parameter '%s'." allMissingParamNames
 
         | [||], _ when caseInfo.IsMandatory && not ignoreMissingMandatory ->
-            error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name.Value
+            error argInfo ErrorCode.PostProcess "missing parameter '%s'." caseInfo.Name
         | _ -> combined
 
     {

--- a/src/Argu/Parsers/KeyValue.fs
+++ b/src/Argu/Parsers/KeyValue.fs
@@ -32,7 +32,7 @@ let private parseKeyValuePartial (state : KeyValueParseState) (caseInfo : UnionC
     let inline success ts = state.Results.AddResults caseInfo ts
 
     try
-        match caseInfo.AppSettingsName.Value with
+        match caseInfo.AppSettingsName with
         | Some name ->
             match (try state.Reader.GetValue name with _ -> null) with
             | null | "" -> ()

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -228,7 +228,7 @@ module Helpers =
             let chars =
                 caseInfo.Value
                 |> Seq.append inheritedParams.Value
-                |> Seq.collect (fun c -> c.CommandLineNames.Value)
+                |> Seq.collect (fun c -> c.CommandLineNames)
                 |> Seq.append helpParam.Flags
                 |> Seq.filter (fun name -> name.Length = 2 && name[0] = '-' && Char.IsLetterOrDigit name[1])
                 |> Seq.map (fun name -> name[1])
@@ -452,7 +452,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
             Array.map getParser fields |> Primitives)
 
-    let commandLineArgs = lazy(
+    let commandLineArgs =
         if isMainCommand.Value || isNoCommandLine then []
         else
             let cliNames = [
@@ -467,20 +467,20 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
             for name in cliNames do validateCliParam name
 
-            cliNames)
+            cliNames
 
-    let appSettingsName = lazy(
+    let appSettingsName =
         if hasAttribute2<NoAppSettingsAttribute> attrs declaringTypeAttrs then None
         else
             match tryGetAttribute<CustomAppSettingsAttribute> attrs with
             | None -> Some <| generateAppSettingsName uci
             | Some _ when parsers.Value.Type = ArgumentType.SubCommand -> arguExn "CustomAppSettings in %O not supported in subcommands." uci
             | Some attr when not <| String.IsNullOrWhiteSpace attr.Name -> Some attr.Name
-            | Some attr -> arguExn "AppSettings parameter '%s' contains invalid characters." attr.Name)
+            | Some attr -> arguExn "AppSettings parameter '%s' contains invalid characters." attr.Name
 
     /// gets the default name of the argument
-    let defaultName = lazy(
-        match commandLineArgs.Value with
+    let defaultName =
+        match commandLineArgs with
         | h :: _ -> h
         | [] when isMainCommand.Value ->
             match parsers.Value with
@@ -489,8 +489,8 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
                 if isRest then name + "..." else name
             | ListParam(_,p) -> "<" + p.Description + ">..."
             | _ -> arguExn "internal error in argu parser representation %O." uci
-        | _ when Option.isSome appSettingsName.Value -> appSettingsName.Value.Value
-        | _ -> arguExn "parameter '%O' needs to have at least one parse source." uci)
+        | _ when Option.isSome appSettingsName -> appSettingsName.Value
+        | _ -> arguExn "parameter '%O' needs to have at least one parse source." uci
 
     let fieldReader = Helpers.fieldReader uci
     let fieldCtor = Helpers.tupleConstructor types
@@ -603,12 +603,12 @@ and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpPar
     let cliIndex = lazy(
         caseInfo.Value
         |> Seq.append inheritedParams.Value
-        |> Seq.collect (fun cs -> cs.CommandLineNames.Value |> Seq.map (fun name -> name, cs))
+        |> Seq.collect (fun cs -> cs.CommandLineNames |> Seq.map (fun name -> name, cs))
         |> PrefixDictionary)
 
     let appSettingsIndex = lazy(
         caseInfo.Value
-        |> Array.choose (fun cs -> match cs.AppSettingsName.Value with Some name -> Some(name, cs) | None -> None)
+        |> Array.choose (fun cs -> match cs.AppSettingsName with Some name -> Some(name, cs) | None -> None)
         |> dict)
 
     let unrecognizedParam = lazy(
@@ -655,7 +655,7 @@ let checkUnionArgInfo (result: UnionArgInfo) =
         // check for conflicting CLI identifiers
         argInfo.Cases.Value
         |> Seq.append argInfo.InheritedParams.Value // this will only have been populated post-construction
-        |> Seq.collect (fun arg -> arg.CommandLineNames.Value |> Seq.map (fun cliName -> cliName, arg))
+        |> Seq.collect (fun arg -> arg.CommandLineNames |> Seq.map (fun cliName -> cliName, arg))
         |> Seq.map (fun (name, arg as t) ->
             if argInfo.HelpParam.IsHelpFlag name then
                 arguExn "parameter '%O' using CLI identifier '%s' which is reserved for help parameters." arg.UnionCaseInfo name
@@ -670,7 +670,7 @@ let checkUnionArgInfo (result: UnionArgInfo) =
         // check for conflicting AppSettings identifiers
         if argInfo.Depth = 0 then
             argInfo.Cases.Value
-            |> Seq.choose(fun arg -> arg.AppSettingsName.Value |> Option.map (fun name -> name, arg))
+            |> Seq.choose(fun arg -> arg.AppSettingsName |> Option.map (fun name -> name, arg))
             |> Seq.groupBy fst
             |> Seq.tryFind(fun (_,args) -> Seq.length args > 1)
             |> Option.iter (fun (name,args) ->
@@ -681,9 +681,8 @@ let checkUnionArgInfo (result: UnionArgInfo) =
         // Evaluate every remaining lazy property to ensure that their checks run.
         // (Strict boolean fields no longer need forcing here.)
         for case in argInfo.Cases.Value do
-            case.Name.Value |> ignore
-            case.CommandLineNames.Value |> ignore
-            case.AppSettingsName.Value |> ignore
+            // Name / CommandLineNames / AppSettingsName are now strict (no lazy)
+            // so they no longer need force-evaluation here.
             case.ParameterInfo.Value |> ignore
             case.MainCommandName.Value |> ignore
             case.CliPosition.Value |> ignore

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -20,7 +20,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
 
     for command in getHierarchy argInfo do
         yield ' '
-        yield command.Name.Value
+        yield command.Name
 
     let! length1 = StringExpr.currentLength
     let offset = length1 - length0
@@ -50,7 +50,7 @@ let mkCommandLineSyntax (argInfo : UnionArgInfo) (prefix : string) (maxWidth : i
     | _ -> ()
 
     for aI in printedCases do
-        match aI.CommandLineNames.Value with
+        match aI.CommandLineNames with
         | [] -> ()
         | name :: _ ->
 
@@ -131,7 +131,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
     if not aI.IsCommandLineArg then () else
     let! start = StringExpr.currentLength
     yield! StringExpr.whiteSpace switchOffset
-    yield String.concat ", " aI.CommandLineNames.Value
+    yield String.concat ", " aI.CommandLineNames
 
     match aI.ParameterInfo.Value with
     | Primitives parsers when aI.IsMainCommand ->
@@ -290,7 +290,7 @@ let rec mkCommandLineArgs (argInfo : UnionArgInfo) (args : seq<obj>) =
 
         let fields = aI.FieldReader.Value t
 
-        let clName() = List.head aI.CommandLineNames.Value
+        let clName() = List.head aI.CommandLineNames
 
         match aI.ParameterInfo.Value with
         | Primitives parsers ->
@@ -358,7 +358,7 @@ let mkAppSettingsDocument (argInfo : UnionArgInfo) printComments (args : 'Templa
             else
                 [|xelem|]
 
-        match aI.AppSettingsName.Value with
+        match aI.AppSettingsName with
         | None -> [||]
         | Some key ->
             match aI.ParameterInfo.Value with

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -53,7 +53,7 @@ with
 type UnionCaseArgInfo =
     {
         /// Human readable name identifier
-        Name : Lazy<string>
+        Name : string
         /// Contextual depth of current argument w.r.t subcommands
         Depth : int
         /// Numbers of parameters in the given union case
@@ -79,9 +79,9 @@ type UnionCaseArgInfo =
         FieldReader : Lazy<obj -> obj[]>
 
         /// head element denotes primary command line arg
-        CommandLineNames : Lazy<string list>
+        CommandLineNames : string list
         /// name used in AppSettings
-        AppSettingsName : Lazy<string option>
+        AppSettingsName : string option
 
         /// Description of the parameter
         Description : Lazy<string>
@@ -119,7 +119,7 @@ type UnionCaseArgInfo =
     }
 with
     member inline x.IsMainCommand = Option.isSome x.MainCommandName.Value
-    member inline x.IsCommandLineArg = match x.CommandLineNames.Value with [] -> x.IsMainCommand | _ -> true
+    member inline x.IsCommandLineArg = match x.CommandLineNames with [] -> x.IsMainCommand | _ -> true
     member inline x.IsCustomAssignment = Option.isSome x.CustomAssignmentSeparator.Value
 
 and [<NoComparison; NoEquality>] ParameterInfo =
@@ -216,11 +216,13 @@ type UnionCaseArgInfo with
         // Internal types are minimal and/or can be changed at will
         // Here we map those to the stable external API contract, which won't be changed until next major ver
         {
-            Name = ucai.Name
+            // Wrap flattened bool/string fields back in Lazy so the public
+            // ArgumentCaseInfo shape is preserved for downstream consumers.
+            Name = lazy ucai.Name
             ArgumentType = ucai.ArgumentType
             UnionCaseInfo = lazy ucai.UnionCaseInfo
-            CommandLineNames = ucai.CommandLineNames
-            AppSettingsName = ucai.AppSettingsName
+            CommandLineNames = lazy ucai.CommandLineNames
+            AppSettingsName = lazy ucai.AppSettingsName
             Description = ucai.Description
             AppSettingsSeparators = Array.toList ucai.AppSettingsSeparators
             AppSettingsSplitOptions = ucai.AppSettingsSplitOptions


### PR DESCRIPTION
perf(UnionCaseArgInfo): Flatten Name / CommandLineNames / AppSettingsName

Three more fields graduate from Lazy<_> to the strict value, matching
the pattern of pr/01-lazy-bool-flatten which did the same for the seven
bool-valued fields. These three are forced on every parse and every
help rendering, so the Lazy wrapper was pure overhead.

* UnionArgInfo.fs: field types are now string, string list, string option.
  IsCommandLineArg reads the strict list directly.
  ToArgumentCaseInfo() wraps the strict values with 'lazy v' so the
  public ArgumentCaseInfo shape (Lazy<_>) is preserved verbatim.
* PreCompute.fs: commandLineArgs, appSettingsName and defaultName are
  computed strictly at construction. The dependency between them is
  unchanged. The trailing checkStructure force-evaluations for these
  three fields are dropped (no lazy left to force).
* Cli.fs / KeyValue.fs / Common.fs / UnParsers.fs / ParseResults.fs:
  drop .Value reads on the now-strict fields. Roughly 20 call sites.

All 112 tests pass unchanged. Public ArgumentCaseInfo unchanged.

---