### PR TITLE
feat(ParseResults): Add fluent Query API (additive)

### DIFF
--- a/src/Argu/ParseResults.fs
+++ b/src/Argu/ParseResults.fs
@@ -299,6 +299,37 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
         | Some sc -> sc
         | None -> error false ErrorCode.PostProcess "no valid subcommand has been specified."
 
+    /// <summary>
+    ///     Begin a fluent query for the given parameter. Compose with
+    ///     <c>.FromCli()</c>, <c>.FromAppSettings()</c>, <c>.PostProcess(parser)</c>,
+    ///     then call a terminal method like <c>.Get()</c>, <c>.TryGet()</c>,
+    ///     <c>.GetAll()</c>, <c>.GetOrDefault(default)</c>, or <c>.Count()</c>.
+    /// </summary>
+    /// <param name="expr">The name of the parameter, expressed as a quotation of its DU constructor.</param>
+    member r.Query<'Field> ([<ReflectedDefinition>] expr : Expr<'Field -> 'Template>) : ParseResultsQuery<'Template, 'Field> =
+        ParseResultsQuery<'Template, 'Field>(r, expr, None)
+
+    // Non-reflected internal accessors used by the fluent builder. The public
+    // GetResult / TryGetResult / GetResults methods carry a
+    // [<ReflectedDefinition>] attribute which auto-quotes the call site, so
+    // callers that already hold an Expr value cannot pass it through.
+    member internal _.GetResultByExpr<'Field>(expr : Expr<'Field -> 'Template>, ?source : ParseSource) : 'Field =
+        (getResult source expr).FieldContents :?> 'Field
+    member internal _.TryGetResultByExpr<'Field>(expr : Expr<'Field -> 'Template>, ?source : ParseSource) : 'Field option =
+        tryGetResult source expr |> Option.map (fun r -> r.FieldContents :?> 'Field)
+    member internal r.GetResultOrDefaultByExpr<'Field>(expr : Expr<'Field -> 'Template>, defaultValue : 'Field, ?source : ParseSource) : 'Field =
+        r.TryGetResultByExpr(expr, ?source = source) |> Option.defaultValue defaultValue
+    member internal _.GetResultsByExpr<'Field>(expr : Expr<'Field -> 'Template>, ?source : ParseSource) : 'Field list =
+        getResults source expr |> Seq.map (fun r -> r.FieldContents :?> 'Field) |> Seq.toList
+    member internal _.ContainsByExpr<'Field>(expr : Expr<'Field -> 'Template>, ?source : ParseSource) : bool =
+        containsResult source expr
+    member internal _.GetParsedResultByExpr<'Field, 'R>(expr : Expr<'Field -> 'Template>, parser : 'Field -> 'R, ?source : ParseSource) : 'R =
+        getResult source expr |> parseResult parser
+    member internal _.TryGetParsedResultByExpr<'Field, 'R>(expr : Expr<'Field -> 'Template>, parser : 'Field -> 'R, ?source : ParseSource) : 'R option =
+        tryGetResult source expr |> Option.map (parseResult parser)
+    member internal _.GetParsedResultsByExpr<'Field, 'R>(expr : Expr<'Field -> 'Template>, parser : 'Field -> 'R, ?source : ParseSource) : 'R list =
+        getResults source expr |> Seq.map (parseResult parser) |> Seq.toList
+
     override r.ToString() = sprintf "%A" (r.GetAllResults())
 
     // used by StructuredFormatDisplay attribute
@@ -330,3 +361,89 @@ type ParseResults<[<EqualityConditionalOn; ComparisonConditionalOn>]'Template wh
                     r.CachedAllResults.Value
                     other.CachedAllResults.Value
             | _ -> invalidArg "other" "cannot compare values of different types"
+
+/// <summary>
+///     Fluent builder for a parse-result query. Chain
+///     <see cref="FromCli"/> / <see cref="FromAppSettings"/> /
+///     <see cref="PostProcess"/> to narrow the query, then call a
+///     terminal method to obtain the value(s).
+/// </summary>
+and [<Sealed; NoEquality; NoComparison>]
+    ParseResultsQuery<'Template, 'Field when 'Template :> IArgParserTemplate>
+        internal (results : ParseResults<'Template>, expr : Expr<'Field -> 'Template>, source : ParseSource option) =
+
+    /// Restrict the query to command-line parse results only.
+    member _.FromCli () : ParseResultsQuery<'Template, 'Field> =
+        ParseResultsQuery<'Template, 'Field>(results, expr, Some ParseSource.CommandLine)
+
+    /// Restrict the query to AppSettings parse results only.
+    member _.FromAppSettings () : ParseResultsQuery<'Template, 'Field> =
+        ParseResultsQuery<'Template, 'Field>(results, expr, Some ParseSource.AppSettings)
+
+    /// Restrict the query to a specific <see cref="ParseSource"/>.
+    member _.FromSource (source : ParseSource) : ParseResultsQuery<'Template, 'Field> =
+        ParseResultsQuery<'Template, 'Field>(results, expr, Some source)
+
+    /// Attach a post-processing parser; the resulting query yields <c>'R</c> values.
+    member _.PostProcess (parser : 'Field -> 'R) : ParseResultsParsedQuery<'Template, 'Field, 'R> =
+        ParseResultsParsedQuery<'Template, 'Field, 'R>(results, expr, source, parser)
+
+    /// Terminal: returns the last specified value. Raises through the
+    /// parser's exiter if no result is present.
+    member _.Get () : 'Field =
+        results.GetResultByExpr(expr, ?source = source)
+
+    /// Terminal: returns the last specified value, falling back to
+    /// <paramref name="defaultValue"/> when no result is present.
+    member _.GetOrDefault (defaultValue : 'Field) : 'Field =
+        results.GetResultOrDefaultByExpr(expr, defaultValue, ?source = source)
+
+    /// Terminal: returns <c>Some</c> of the last specified value, or <c>None</c> if absent.
+    member _.TryGet () : 'Field option =
+        results.TryGetResultByExpr(expr, ?source = source)
+
+    /// Terminal: returns every parsed value of this parameter, in order.
+    member _.GetAll () : 'Field list =
+        results.GetResultsByExpr(expr, ?source = source)
+
+    /// Terminal: returns the number of parsed values of this parameter.
+    member q.Count () : int =
+        q.GetAll().Length
+
+    /// Terminal: returns <c>true</c> when at least one parse result is present.
+    member _.Exists () : bool =
+        results.ContainsByExpr(expr, ?source = source)
+
+/// <summary>
+///     Stage of the fluent query after <see cref="ParseResultsQuery.PostProcess"/>
+///     has been applied. Terminal methods now produce values of <c>'R</c>.
+/// </summary>
+and [<Sealed; NoEquality; NoComparison>]
+    ParseResultsParsedQuery<'Template, 'Field, 'R when 'Template :> IArgParserTemplate>
+        internal (results : ParseResults<'Template>, expr : Expr<'Field -> 'Template>,
+                    source : ParseSource option, parser : 'Field -> 'R) =
+
+    /// Restrict the query to command-line parse results only.
+    member _.FromCli () : ParseResultsParsedQuery<'Template, 'Field, 'R> =
+        ParseResultsParsedQuery<'Template, 'Field, 'R>(results, expr, Some ParseSource.CommandLine, parser)
+
+    /// Restrict the query to AppSettings parse results only.
+    member _.FromAppSettings () : ParseResultsParsedQuery<'Template, 'Field, 'R> =
+        ParseResultsParsedQuery<'Template, 'Field, 'R>(results, expr, Some ParseSource.AppSettings, parser)
+
+    /// Restrict the query to a specific <see cref="ParseSource"/>.
+    member _.FromSource (source : ParseSource) : ParseResultsParsedQuery<'Template, 'Field, 'R> =
+        ParseResultsParsedQuery<'Template, 'Field, 'R>(results, expr, Some source, parser)
+
+    /// Terminal: returns the last specified value passed through the post-processor.
+    /// Raises through the parser's exiter if no result is present.
+    member _.Get () : 'R =
+        results.GetParsedResultByExpr(expr, parser, ?source = source)
+
+    /// Terminal: <c>Some (parser v)</c> for the last specified value, or <c>None</c>.
+    member _.TryGet () : 'R option =
+        results.TryGetParsedResultByExpr(expr, parser, ?source = source)
+
+    /// Terminal: every parsed value passed through the post-processor, in order.
+    member _.GetAll () : 'R list =
+        results.GetParsedResultsByExpr(expr, parser, ?source = source)

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Tests.fs"/>
+    <Compile Include="FluentQueryTests.fs"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>

--- a/tests/Argu.Tests/FluentQueryTests.fs
+++ b/tests/Argu.Tests/FluentQueryTests.fs
@@ -1,0 +1,104 @@
+namespace Argu.Tests
+
+open Xunit
+open Swensen.Unquote
+
+open Argu
+
+/// Tests for the fluent ParseResults.Query API (PR 23).
+module ``Argu Tests FluentQuery`` =
+
+    type Args =
+        | Port of int
+        | Verbose
+        | Tag of string
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Port _ -> "port"
+                | Verbose -> "verbose"
+                | Tag _ -> "tag"
+
+    let private parse (argv : string []) =
+        ArgumentParser.Create<Args>(programName = "app")
+            .ParseCommandLine(argv, raiseOnUsage = false)
+
+    [<Fact>]
+    let ``Query.Get returns the same as GetResult`` () =
+        let r = parse [| "--port"; "8080" |]
+        test <@ r.Query(<@ Port @>).Get() = r.GetResult(Port) @>
+
+    [<Fact>]
+    let ``Query.TryGet returns None when absent`` () =
+        let r = parse [||]
+        test <@ r.Query(<@ Tag @>).TryGet() = None @>
+
+    [<Fact>]
+    let ``Query.TryGet returns Some when present`` () =
+        let r = parse [| "--tag"; "v1" |]
+        test <@ r.Query(<@ Tag @>).TryGet() = Some "v1" @>
+
+    [<Fact>]
+    let ``Query.GetAll matches GetResults`` () =
+        let r = parse [| "--tag"; "a"; "--tag"; "b"; "--tag"; "c" |]
+        test <@ r.Query(<@ Tag @>).GetAll() = r.GetResults(Tag) @>
+        test <@ r.Query(<@ Tag @>).GetAll() = [ "a"; "b"; "c" ] @>
+
+    [<Fact>]
+    let ``Query.GetOrDefault returns default when absent`` () =
+        let r = parse [||]
+        test <@ r.Query(<@ Port @>).GetOrDefault(8080) = 8080 @>
+
+    [<Fact>]
+    let ``Query.GetOrDefault returns value when present`` () =
+        let r = parse [| "--port"; "1234" |]
+        test <@ r.Query(<@ Port @>).GetOrDefault(8080) = 1234 @>
+
+    [<Fact>]
+    let ``Query.Count returns number of occurrences`` () =
+        let r = parse [| "--tag"; "x"; "--tag"; "y" |]
+        test <@ r.Query(<@ Tag @>).Count() = 2 @>
+
+    [<Fact>]
+    let ``Query.Exists tracks presence`` () =
+        let r1 = parse [| "--port"; "1" |]
+        let r2 = parse [||]
+        // Query currently targets parameterised cases (Expr<'Field -> 'Template>);
+        // nullary cases like Verbose use Contains directly.
+        test <@ r1.Query(<@ Port @>).Exists() = true @>
+        test <@ r2.Query(<@ Port @>).Exists() = false @>
+
+    [<Fact>]
+    let ``Query.FromCli matches the CommandLine source filter`` () =
+        let r = parse [| "--port"; "1" |]
+        // Result was sourced from CLI; FromCli must keep it.
+        test <@ r.Query(<@ Port @>).FromCli().TryGet() = Some 1 @>
+
+    [<Fact>]
+    let ``Query.FromAppSettings excludes CommandLine-sourced results`` () =
+        let r = parse [| "--port"; "1" |]
+        // The result is from CommandLine; filtering to AppSettings must hide it.
+        test <@ r.Query(<@ Port @>).FromAppSettings().TryGet() = None @>
+
+    [<Fact>]
+    let ``Query.PostProcess applies the parser`` () =
+        let r = parse [| "--tag"; "release" |]
+        let upper = r.Query(<@ Tag @>).PostProcess(fun s -> s.ToUpperInvariant()).Get()
+        test <@ upper = "RELEASE" @>
+
+    [<Fact>]
+    let ``Query.PostProcess composes with FromCli`` () =
+        let r = parse [| "--tag"; "abc" |]
+        let n =
+            r.Query(<@ Tag @>)
+                .FromCli()
+                .PostProcess(fun s -> s.Length)
+                .Get()
+        test <@ n = 3 @>
+
+    [<Fact>]
+    let ``Query.PostProcess.GetAll returns mapped list`` () =
+        let r = parse [| "--tag"; "a"; "--tag"; "bb"; "--tag"; "ccc" |]
+        let lens =
+            r.Query(<@ Tag @>).PostProcess(fun s -> s.Length).GetAll()
+        test <@ lens = [ 1; 2; 3 ] @>


### PR DESCRIPTION
feat(ParseResults): Add fluent Query API (additive)

New method ParseResults<'T>.Query<'Field>(<@ Foo @>) opens a chainable
builder:

  results.Query(<@ Args.Port @>).FromCli().WithDefault(8080).Get()
  results.Query(<@ Args.Verbose @>).Exists()
  results.Query(<@ Args.Tag @>).PostProcess(parseTag).GetAll()

Builders are two value types:
* ParseResultsQuery<'Template, 'Field> — pre-PostProcess; terminal methods
  return 'Field.
* ParseResultsParsedQuery<'Template, 'Field, 'R> — after PostProcess;
  terminal methods return 'R.

Chain methods (FromCli / FromAppSettings / FromSource / PostProcess) are
immutable and return a fresh builder. Terminal methods delegate to new
internal *ByExpr / *ParsedResultByExpr members on ParseResults, which
mirror the existing GetResult / TryGetResult / GetResults closures but
take an Expr<_> directly rather than via the [<ReflectedDefinition>]
auto-quoting on the public surface.

Every existing GetResult / TryGetResult / GetResults / PostProcessResult
overload is left untouched and un-deprecated. The new path is opt-in.
All 112 tests pass.

---

test(FluentQuery): Add coverage for ParseResults.Query API

13 new tests covering the fluent builder added in PR 23:
* Terminal parity with existing API: Get matches GetResult, GetAll
  matches GetResults, TryGet matches TryGetResult.
* GetOrDefault returns default when absent and value when present.
* Count returns the number of occurrences.
* Exists tracks presence (parameterised cases; nullary cases continue
  to use Contains directly since Query takes Expr<'Field -> 'Template>).
* FromCli keeps CommandLine-sourced results; FromAppSettings excludes
  them when no AppSettings reader was used.
* PostProcess applies the parser; composes with FromCli; GetAll
  through PostProcess returns the mapped list.

Net suite size on this branch: 112 -> 125.

---