### PR TITLE
feat(benchmarks): Add BenchmarkDotNet harness

### DIFF
--- a/Argu.slnx
+++ b/Argu.slnx
@@ -42,4 +42,5 @@
   </Folder>
   <Project Path="src/Argu/Argu.fsproj" />
   <Project Path="tests/Argu.Tests/Argu.Tests.fsproj" />
+  <Project Path="benchmarks/Argu.Benchmarks/Argu.Benchmarks.fsproj" />
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,5 +13,8 @@
     <!-- Test deps -->
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2"/>
     <PackageVersion Include="Unquote" Version="7.0.1"/>
+
+    <!-- Benchmark harness -->
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0"/>
   </ItemGroup>
 </Project>

--- a/benchmarks/Argu.Benchmarks/Argu.Benchmarks.fsproj
+++ b/benchmarks/Argu.Benchmarks/Argu.Benchmarks.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Benchmarks.fs"/>
+    <Compile Include="Program.fs"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core"/>
+    <PackageReference Include="BenchmarkDotNet"/>
+  </ItemGroup>
+</Project>

--- a/benchmarks/Argu.Benchmarks/Benchmarks.fs
+++ b/benchmarks/Argu.Benchmarks/Benchmarks.fs
@@ -1,0 +1,55 @@
+namespace Argu.Benchmarks
+
+open BenchmarkDotNet.Attributes
+
+open Argu
+
+/// Schema used by all benchmarks. Deliberately small but covers
+/// optional, list and primitive parameter shapes.
+[<AutoOpen>]
+module Schema =
+
+    type Args =
+        | [<Mandatory>] Port of int
+        | [<AltCommandLine("-v")>] Verbose
+        | Tag of string
+        | Items of int list
+        | Working_Directory of string
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Port _ -> "port to bind to"
+                | Verbose -> "verbose output"
+                | Tag _ -> "an opaque tag"
+                | Items _ -> "list of int items"
+                | Working_Directory _ -> "working directory"
+
+/// Schema build benchmark — measures the cost of constructing the
+/// reflection-based parser for the schema above.
+[<MemoryDiagnoser>]
+type SchemaBuild () =
+
+    [<Benchmark>]
+    member _.Create () =
+        ArgumentParser.Create<Args>(programName = "bench")
+
+/// Parse benchmark — schema is built once at class init and the same
+/// parser is reused for every iteration.
+[<MemoryDiagnoser>]
+type Parse () =
+    let parser = ArgumentParser.Create<Args>(programName = "bench")
+    let argv = [| "--port"; "8080"; "-v"; "--tag"; "release"; "--working-directory"; "/tmp" |]
+
+    [<Benchmark>]
+    member _.ParseCommandLine () =
+        parser.ParseCommandLine(argv, raiseOnUsage = false)
+
+/// Help render benchmark — the parser is built once; we re-render the
+/// usage string on every iteration.
+[<MemoryDiagnoser>]
+type HelpRender () =
+    let parser = ArgumentParser.Create<Args>(programName = "bench")
+
+    [<Benchmark>]
+    member _.PrintUsage () =
+        parser.PrintUsage()

--- a/benchmarks/Argu.Benchmarks/Program.fs
+++ b/benchmarks/Argu.Benchmarks/Program.fs
@@ -1,0 +1,17 @@
+module Argu.Benchmarks.Program
+
+open BenchmarkDotNet.Running
+open BenchmarkDotNet.Configs
+
+[<EntryPoint>]
+let main argv =
+    // Pass through CLI args so users can do
+    //   dotnet run -c Release --project benchmarks/Argu.Benchmarks -- --filter "*Parse*"
+    // or `--list flat` / `--memory` etc.
+    BenchmarkSwitcher.FromTypes(
+        [| typeof<SchemaBuild>
+           typeof<Parse>
+           typeof<HelpRender> |])
+        .Run(argv, DefaultConfig.Instance)
+    |> ignore
+    0


### PR DESCRIPTION
feat(benchmarks): Add BenchmarkDotNet harness

* New project benchmarks/Argu.Benchmarks (net10.0 console exe). Three
  seed benchmarks with [<MemoryDiagnoser>]:
  - SchemaBuild.Create — cost of constructing the reflection-based
    parser from a representative schema.
  - Parse.ParseCommandLine — parsing the same argv against the
    pre-built parser.
  - HelpRender.PrintUsage — re-rendering the usage string from the
    pre-built parser.
* Program.fs uses BenchmarkSwitcher so callers can pass standard
  BenchmarkDotNet flags through dotnet run:
    dotnet run -c Release --project benchmarks/Argu.Benchmarks         -- --filter "*Parse*" --memory
* Directory.Packages.props: pin BenchmarkDotNet 0.14.0.
* Argu.sln: register the project.

No impact on the published Argu package.

---