### PR TITLE
feat(Attributes): Add unified SeparatorAttribute; obsolete 6 subsumed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Fix Clarify exception in expr2Uci [#293](https://github.com/fsprojects/Argu/pull/293) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Report all missing args in error message, not just first level [#297](https://github.com/fsprojects/Argu/pull/297) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Limit min wordwrap column to 20 [#302](https://github.com/fsprojects/Argu/pull/302) [@dimension-zero](https://github.com/dimension-zero)
+* Add `Separator("=", orSpace = true)` attribute to replace `EqualsAssignmentAttribute`, `ColonAssignmentAttribute`, `CustomAssignmentAttribute`, `EqualsAssignmentOrSpacedAttribute`, `ColonAssignmentOrSpacedAttribute` and `CustomAssignmentOrSpacedAttribute` [#315](https://github.com/fsprojects/Argu/pull/315) [@dimension-zero](https://github.com/dimension-zero)
 * Add `Argu.Samples.Introspect` sample [#298](https://github.com/fsprojects/Argu/pull/298) [@dimension-zero](https://github.com/dimension-zero)
 * Add `ArgumentParser.Parse(ParseConfig)` [#307](https://github.com/fsprojects/Argu/pull/307) [@dimension-zero](https://github.com/dimension-zero)
 * Add `ArgumentParser.PrintUsage(..., ?UsageStrings)` for localization support [#303](https://github.com/fsprojects/Argu/pull/303) [@dimension-zero](https://github.com/dimension-zero)

--- a/docs/perf.fsx
+++ b/docs/perf.fsx
@@ -21,7 +21,7 @@ type FactAttribute () = inherit System.Attribute()
 
 ## Introduction
 
-Argu simplicity is achieved via Reflection and as such it's performance heavily depends on the size and depth of the
+Argu simplicity is achieved via Reflection and as such its performance heavily depends on the size and depth of the
 discriminated union used.
 
 For applications that wants to get a little more performance out of Argu it's also possible to get a little more

--- a/docs/perf.fsx
+++ b/docs/perf.fsx
@@ -21,7 +21,7 @@ type FactAttribute () = inherit System.Attribute()
 
 ## Introduction
 
-Argu simplicity is achieved via Reflection and as such it's performance heavily depend on the size and depth of the
+Argu simplicity is achieved via Reflection and as such it's performance heavily depends on the size and depth of the
 discriminated union used.
 
 For applications that wants to get a little more performance out of Argu it's also possible to get a little more

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -150,8 +150,8 @@ type Argument =
     | [<Mandatory>] Cache_Path of path: string
     | [<NoCommandLine>] Connection_String of conn: string
     | [<Unique>] Listener of host: string * port: int
-    | [<EqualsAssignment>] Assignment of value: string
-    | [<EqualsAssignmentOrSpaced>] AssignmentOrSpace of value: string
+    | [<Separator "=">] Assignment of value: string
+    | [<Separator("=", orSpace = true)>] AssignmentOrSpace of value: string
     | [<AltCommandLine("-p")>] Primary_Port of tcp_port: int
 
 (**
@@ -164,9 +164,9 @@ In this case,
 
   * [`AltCommandLine`](reference/argu-arguattributes-altcommandlineattribute.html): specifies an alternative command line switch.
 
-  * [`EqualsAssignment`](reference/argu-arguattributes-equalsassignmentattribute.html) : enforces `--assignment=value` and `--assignment key=value` CLI syntax.
+  * [`Separator "="`](reference/argu-arguattributes-separatorattribute.html) : enforces `--assignment=value` and `--assignment key=value` CLI syntax.
 
-  * [`EqualsAssignmentOrSpaced`](reference/argu-arguattributes-equalsassignmentorspacedattribute.html) : enforces `--assignment=value` and `--assignment value` CLI syntax.
+  * [`Separator("=", orSpace = true)`](reference/argu-arguattributes-separatorattribute.html) : enforces `--assignment=value` and `--assignment value` CLI syntax.
 
   * [`Unique`](reference/argu-arguattributes-uniqueattribute.html) : parser will fail if CLI provides this argument more than once.
 
@@ -177,8 +177,6 @@ Many more attributes are also available, such as
   * [`Hidden`](reference/argu-arguattributes-hiddenattribute.html): do not display in the help usage string.
 
   * [`CustomAppSettings`](reference/argu-arguattributes-customappsettingsattribute.html): sets a custom key name for AppSettings.
-
-  * [`CustomAssignment`](reference/argu-arguattributes-customassignmentattribute.html): works like EqualsAssignment but with a custom separator string.
 
 Please see the [API Reference](http://fsprojects.github.io/Argu/reference/argu-arguattributes.html)
 for a complete list of all attributes provided by Argu.
@@ -202,7 +200,7 @@ Additionally, it is possible to specify argument parameters that are either opti
 *)
 
 type VariadicParameters =
-    | [<EqualsAssignment>] Enable_Logging of path: string option
+    | [<Separator "=">] Enable_Logging of path: string option
     | Tcp_Ports of port: int list
 
 (**
@@ -340,7 +338,7 @@ let main argv =
     try
         parser.ParseCommandLine(inputs = argv, raiseOnUsage = true) |> ignore
         0
-    with :? ArguParseException as e -> eprintfn "%s" e.Message; 1
+    with :? ArguParseException as e -> eprintfn $"%s{e.Message}"; 1
 
 (**
 

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -164,9 +164,9 @@ In this case,
 
   * [`AltCommandLine`](reference/argu-arguattributes-altcommandlineattribute.html): specifies an alternative command line switch.
 
-  * [`Separator "="`](reference/argu-arguattributes-separatorattribute.html) : enforces `--assignment=value` and `--assignment key=value` CLI syntax.
+  * [`Separator "="`](reference/argu-arguattributes-separatorattribute.html) : enforces `--assignment=value` or `--assignment key=value` CLI syntax.
 
-  * [`Separator("=", orSpace = true)`](reference/argu-arguattributes-separatorattribute.html) : enforces `--assignment=value` and `--assignment value` CLI syntax.
+  * [`Separator("=", orSpace = true)`](reference/argu-arguattributes-separatorattribute.html) : allows `--assignment=value` or `--assignment value` CLI syntax.
 
   * [`Unique`](reference/argu-arguattributes-uniqueattribute.html) : parser will fail if CLI provides this argument more than once.
 

--- a/samples/Argu.Samples.LS/Arguments.fs
+++ b/samples/Argu.Samples.LS/Arguments.fs
@@ -34,13 +34,13 @@ type LsArguments =
     | [<AltCommandLine("-A")>] Almost_All
     | Author
     | [<AltCommandLine("-b")>] Escape
-    | [<EqualsAssignment>] Block_Size of SIZE:Size
+    | [<Assignment "=">] Block_Size of SIZE:Size
     | [<AltCommandLine("-B")>] Ignore_Backups
-    | [<AltCommandLine("-C"); EqualsAssignment>] Color of WHEN:ColorWhen option
+    | [<AltCommandLine("-C"); Assignment "=">] Color of WHEN:ColorWhen option
     | [<AltCommandLine("-d")>] Directory
     | [<AltCommandLine("-D")>] Dired
     | [<CliPrefix(CliPrefix.Dash)>] F
-    | [<AltCommandLine("-F", "--classify", "--file-type"); EqualsAssignment>] Format of WORD:string option
+    | [<AltCommandLine("-F", "--classify", "--file-type"); Assignment "=">] Format of WORD:string option
     | [<AltCommandLine("-g")>] Group_Directories_First
     | [<AltCommandLine("-G")>] No_Group
     | [<AltCommandLine("-h")>] Human_Readable
@@ -53,11 +53,11 @@ type LsArguments =
     | [<AltCommandLine("-n")>] Numeric_Uid_Guid
     | [<AltCommandLine("-N")>] Literal
     | [<CliPrefix(CliPrefix.Dash)>] O
-    | [<AltCommandLine("-p"); EqualsAssignment>] Indicator_Style of slash:char
+    | [<AltCommandLine("-p"); Assignment "=">] Indicator_Style of slash:char
     | [<AltCommandLine("-q")>] Hide_Control_Chars
     | Show_Control_Chars
     | [<AltCommandLine("-Q")>] Quote_Name
-    | [<EqualsAssignment>] Quoting_Style of WORD:QuotingStyle
+    | [<Assignment "=">] Quoting_Style of WORD:QuotingStyle
     | [<AltCommandLine("-r")>] Reverse
     | [<AltCommandLine("-R")>] Recursive
     | [<AltCommandLine("-s")>] Size

--- a/samples/Argu.Samples.LS/Arguments.fs
+++ b/samples/Argu.Samples.LS/Arguments.fs
@@ -34,13 +34,13 @@ type LsArguments =
     | [<AltCommandLine("-A")>] Almost_All
     | Author
     | [<AltCommandLine("-b")>] Escape
-    | [<Assignment "=">] Block_Size of SIZE:Size
+    | [<Separator "=">] Block_Size of SIZE:Size
     | [<AltCommandLine("-B")>] Ignore_Backups
-    | [<AltCommandLine("-C"); Assignment "=">] Color of WHEN:ColorWhen option
+    | [<AltCommandLine("-C"); Separator "=">] Color of WHEN:ColorWhen option
     | [<AltCommandLine("-d")>] Directory
     | [<AltCommandLine("-D")>] Dired
     | [<CliPrefix(CliPrefix.Dash)>] F
-    | [<AltCommandLine("-F", "--classify", "--file-type"); Assignment "=">] Format of WORD:string option
+    | [<AltCommandLine("-F", "--classify", "--file-type"); Separator "=">] Format of WORD:string option
     | [<AltCommandLine("-g")>] Group_Directories_First
     | [<AltCommandLine("-G")>] No_Group
     | [<AltCommandLine("-h")>] Human_Readable
@@ -53,11 +53,11 @@ type LsArguments =
     | [<AltCommandLine("-n")>] Numeric_Uid_Guid
     | [<AltCommandLine("-N")>] Literal
     | [<CliPrefix(CliPrefix.Dash)>] O
-    | [<AltCommandLine("-p"); Assignment "=">] Indicator_Style of slash:char
+    | [<AltCommandLine("-p"); Separator "=">] Indicator_Style of slash:char
     | [<AltCommandLine("-q")>] Hide_Control_Chars
     | Show_Control_Chars
     | [<AltCommandLine("-Q")>] Quote_Name
-    | [<Assignment "=">] Quoting_Style of WORD:QuotingStyle
+    | [<Separator "=">] Quoting_Style of WORD:QuotingStyle
     | [<AltCommandLine("-r")>] Reverse
     | [<AltCommandLine("-R")>] Recursive
     | [<AltCommandLine("-s")>] Size

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -2,12 +2,6 @@
 [<AutoOpen>]
 module Argu.ArguAttributes
 
-// Several attributes in this file are deprecated but kept as functional
-// wrappers for source-compat (e.g. EqualsAssignmentAttribute inherits from
-// the now-obsolete CustomAssignmentAttribute). #nowarn 44 silences the
-// resulting FS0044 inside this file; callers still see the warning.
-#nowarn "44"
-
 open System
 
 /// Parse multiple parameters in AppSettings as comma separated values. OBSOLETE
@@ -122,14 +116,14 @@ type PrintLabelsAttribute () = inherit Attribute ()
 /// <summary>
 /// Overrides the standard <c>--param value</c> and <c>--param value1 value2</c> (for tuple values) CLI format rules to accept an alternate separator.<br/>
 /// <i>(for single values)</i> Switches accepted format to: <c>--param&lt;separator&gt;arg</c><br/>
-/// <i>(for tuple values)</i> Opts into accepting<c>--param key&lt;separator&gt;value</c>.<br/>
+/// <i>(for tuple values)</i> Opts into accepting <c>--param key&lt;separator&gt;value</c>.<br/>
 /// Optionally, if <paramref name="orSpace"/> is <c>true</c>, the format <c>--param value</c> will also be accepted (but only for single parameters).
 /// </summary>
 /// <remarks>
 /// Unified attribute that subsumes the six legacy predecessors: <c>CustomAssignment</c>,
 /// <c>EqualsAssignment</c>, <c>ColonAssignment</c>, <c>CustomAssignmentOrSpacedAttribute</c>,  and the associated <c>*OrSpaced</c> variants.<br/>
 /// </remarks>
-[<AttributeUsage(AttributeTargets.Method, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type SeparatorAttribute(separator : string, orSpace : bool) =
     inherit Attribute ()
     new (separator : string) = SeparatorAttribute(separator, false)
@@ -149,6 +143,7 @@ type CustomAssignmentAttribute (separator : string) =
     /// The assignment separator string (e.g. "=" or ":").
     member _.Separator = separator
 
+#nowarn 44 // These derive from an Obsolete root attribute, but we can't remove them
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
@@ -190,6 +185,7 @@ type EqualsAssignmentOrSpacedAttribute () =
 [<Obsolete("Use [<Separator(\":\", orSpace = true)>] instead.")>]
 type ColonAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute(":")
+#warnon 44
 
 /// Declares a custom default CLI identifier for the current parameter.
 /// Replaces the auto-generated identifier name.

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -2,6 +2,12 @@
 [<AutoOpen>]
 module Argu.ArguAttributes
 
+// Several attributes in this file are deprecated but kept as functional
+// wrappers for source-compat (e.g. EqualsAssignmentAttribute inherits from
+// the now-obsolete CustomAssignmentAttribute). #nowarn 44 silences the
+// resulting FS0044 inside this file; callers still see the warning.
+#nowarn "44"
+
 open System
 
 /// Parse multiple parameters in AppSettings as comma separated values. OBSOLETE
@@ -113,11 +119,31 @@ type MainCommandAttribute (argumentName : string) =
 [<Obsolete("Argu 3.0 prints union labels by default. Please remove this attribute.")>]
 type PrintLabelsAttribute () = inherit Attribute ()
 
+/// <summary>
+///     Single assignment-attribute that subsumes the six legacy
+///     <c>CustomAssignment</c> / <c>EqualsAssignment</c> /
+///     <c>ColonAssignment</c> / <c>*OrSpaced</c> attributes.
+///     Provide the literal separator string (e.g. <c>"="</c>) and a flag
+///     indicating whether spaced form (<c>--param value</c>) should also
+///     be accepted. When <paramref name="allowSpaced"/> is <c>true</c>,
+///     the parameter must have arity 1. Otherwise arity 1 or 2 are both
+///     supported.
+/// </summary>
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+type AssignmentAttribute (separator : string, allowSpaced : bool) =
+    inherit Attribute ()
+    new (separator : string) = AssignmentAttribute(separator, false)
+    /// The assignment separator string (e.g. "=" or ":").
+    member _.Separator = separator
+    /// When <c>true</c>, the spaced form is also accepted alongside the separator form.
+    member _.AllowSpaced = allowSpaced
+
 /// Use a custom separator for parameter assignment.
 /// e.g. '--param<separator>arg' or '--param key<separator>value'.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 /// Can be used to specify any assignment separator.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(separator)>] instead.")>]
 type CustomAssignmentAttribute (separator : string) =
     inherit Attribute ()
     /// The assignment separator string (e.g. "=" or ":").
@@ -126,12 +152,14 @@ type CustomAssignmentAttribute (separator : string) =
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(\"=\")>] instead.")>]
 type EqualsAssignmentAttribute () =
     inherit CustomAssignmentAttribute("=")
 
 /// Use '--param:arg' or '--param key:value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(\":\")>] instead.")>]
 type ColonAssignmentAttribute () =
     inherit CustomAssignmentAttribute(":")
 
@@ -141,6 +169,7 @@ type ColonAssignmentAttribute () =
 /// Requires that the argument should have parameters of arity 1 only.
 /// Can be used to specify any assignment separator.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(separator, allowSpaced = true)>] instead.")>]
 type CustomAssignmentOrSpacedAttribute (separator : string) =
     inherit Attribute ()
     /// The assignment separator string (e.g. "=" or ":"). Spaced form is also accepted.
@@ -150,6 +179,7 @@ type CustomAssignmentOrSpacedAttribute (separator : string) =
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(\"=\", allowSpaced = true)>] instead.")>]
 type EqualsAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute("=")
 
@@ -157,6 +187,7 @@ type EqualsAssignmentOrSpacedAttribute () =
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<Obsolete("Use [<Assignment(\":\", allowSpaced = true)>] instead.")>]
 type ColonAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute(":")
 

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -128,7 +128,7 @@ type PrintLabelsAttribute () = inherit Attribute ()
 /// Unified attribute that subsumes the six legacy predecessors: <c>CustomAssignment</c>,
 /// <c>EqualsAssignment</c>, <c>ColonAssignment</c> and the <c>*OrSpaced</c> attributes.<br/>
 /// </remarks>
-[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
+[<AttributeUsage(AttributeTargets.Method, AllowMultiple = false)>]
 type AssignmentAttribute (separator : string, allowSpaced : bool) =
     inherit Attribute ()
     new (separator : string) = AssignmentAttribute(separator, false)

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -120,29 +120,30 @@ type MainCommandAttribute (argumentName : string) =
 type PrintLabelsAttribute () = inherit Attribute ()
 
 /// <summary>
-/// Use a custom separator for parameter assignment.<br/>
-/// When <paramref name="allowSpaced"/> is <c>true</c>, the format <c>--param value</c> will also be accepted.<br/>
-/// Otherwise <c>'--param&lt;separator&gt;arg'</c> or <c>'--param key&lt;separator&gt;value'</c> are accepted.<br/>
+/// Overrides the standard <c>--param value</c> and <c>--param value1 value2</c> (for tuple values) CLI format rules to accept an alternate separator.<br/>
+/// <i>(for single values)</i> Switches accepted format to: <c>--param&lt;separator&gt;arg</c><br/>
+/// <i>(for tuple values)</i> Opts into accepting<c>--param key&lt;separator&gt;value</c>.<br/>
+/// Optionally, if <paramref name="orSpace"/> is <c>true</c>, the format <c>--param value</c> will also be accepted (but only for single parameters).
 /// </summary>
 /// <remarks>
 /// Unified attribute that subsumes the six legacy predecessors: <c>CustomAssignment</c>,
-/// <c>EqualsAssignment</c>, <c>ColonAssignment</c> and the <c>*OrSpaced</c> attributes.<br/>
+/// <c>EqualsAssignment</c>, <c>ColonAssignment</c>, <c>CustomAssignmentOrSpacedAttribute</c>,  and the associated <c>*OrSpaced</c> variants.<br/>
 /// </remarks>
 [<AttributeUsage(AttributeTargets.Method, AllowMultiple = false)>]
-type AssignmentAttribute (separator : string, allowSpaced : bool) =
+type SeparatorAttribute(separator : string, orSpace : bool) =
     inherit Attribute ()
-    new (separator : string) = AssignmentAttribute(separator, false)
-    /// The assignment separator string (e.g. "=" or ":").
+    new (separator : string) = SeparatorAttribute(separator, false)
+    /// The value separator string (e.g. "=" or ":").
     member _.Separator = separator
-    /// When <c>true</c>, the spaced form (<c>--param value</c>) is also accepted alongside the separator form (only supported for non-keyed parameters).
-    member _.AllowSpaced = allowSpaced
+    /// When <c>true</c>, the spaced form (<c>--param value</c>) is also accepted alongside the separator form (but only for single parameters).
+    member _.OrSpace = orSpace
 
 /// Use a custom separator for parameter assignment.
 /// e.g. '--param<separator>arg' or '--param key<separator>value'.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 /// Can be used to specify any assignment separator.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(separator)>] instead.")>]
+[<Obsolete("Use [<Separator(separator)>] instead.")>]
 type CustomAssignmentAttribute (separator : string) =
     inherit Attribute ()
     /// The assignment separator string (e.g. "=" or ":").
@@ -151,14 +152,14 @@ type CustomAssignmentAttribute (separator : string) =
 /// Use '--param=arg' or '--param key=value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(\"=\")>] instead.")>]
+[<Obsolete("Use [<Separator(\"=\")>] instead.")>]
 type EqualsAssignmentAttribute () =
     inherit CustomAssignmentAttribute("=")
 
 /// Use '--param:arg' or '--param key:value' assignment syntax in CLI.
 /// Requires that the argument should have parameters of arity 1 or 2 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(\":\")>] instead.")>]
+[<Obsolete("Use [<Separator(\":\")>] instead.")>]
 type ColonAssignmentAttribute () =
     inherit CustomAssignmentAttribute(":")
 
@@ -168,7 +169,7 @@ type ColonAssignmentAttribute () =
 /// Requires that the argument should have parameters of arity 1 only.
 /// Can be used to specify any assignment separator.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(separator, allowSpaced = true)>] instead.")>]
+[<Obsolete("Use [<Separator(separator, orSpace = true)>] instead.")>]
 type CustomAssignmentOrSpacedAttribute (separator : string) =
     inherit Attribute ()
     /// The assignment separator string (e.g. "=" or ":"). Spaced form is also accepted.
@@ -178,7 +179,7 @@ type CustomAssignmentOrSpacedAttribute (separator : string) =
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(\"=\", allowSpaced = true)>] instead.")>]
+[<Obsolete("Use [<Separator(\"=\", orSpace = true)>] instead.")>]
 type EqualsAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute("=")
 
@@ -186,7 +187,7 @@ type EqualsAssignmentOrSpacedAttribute () =
 /// Parameters can also be assigned using space as separator e.g. '--param arg'
 /// Requires that the argument should have parameters of arity 1 only.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
-[<Obsolete("Use [<Assignment(\":\", allowSpaced = true)>] instead.")>]
+[<Obsolete("Use [<Separator(\":\", orSpace = true)>] instead.")>]
 type ColonAssignmentOrSpacedAttribute () =
     inherit CustomAssignmentOrSpacedAttribute(":")
 
@@ -225,13 +226,13 @@ type AppSettingsSeparatorAttribute ([<ParamArray>] separators : string [], split
     new (separator : char) = AppSettingsSeparatorAttribute([|string separator|], StringSplitOptions.None)
     /// The separator strings used to split AppSettings list/CSV values.
     member _.Separators = separators
-    /// Split options applied during AppSettings list/CSV value separation.
+    /// <summary>Split options applied during AppSettings list/CSV value separation. Default: <c>None</c></summary>
     member _.SplitOptions = splitOptions
 
 /// Specifies a custom prefix for auto-generated CLI names.
 /// This defaults to double dash ('--').
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Class, AllowMultiple = false)>]
-type CliPrefixAttribute(prefix : string) =
+type CliPrefixAttribute (prefix : string) =
     inherit Attribute()
     /// The auto-generation prefix (e.g. "--", "-", or empty).
     member _.Prefix = prefix

--- a/src/Argu/Attributes.fs
+++ b/src/Argu/Attributes.fs
@@ -120,22 +120,21 @@ type MainCommandAttribute (argumentName : string) =
 type PrintLabelsAttribute () = inherit Attribute ()
 
 /// <summary>
-///     Single assignment-attribute that subsumes the six legacy
-///     <c>CustomAssignment</c> / <c>EqualsAssignment</c> /
-///     <c>ColonAssignment</c> / <c>*OrSpaced</c> attributes.
-///     Provide the literal separator string (e.g. <c>"="</c>) and a flag
-///     indicating whether spaced form (<c>--param value</c>) should also
-///     be accepted. When <paramref name="allowSpaced"/> is <c>true</c>,
-///     the parameter must have arity 1. Otherwise arity 1 or 2 are both
-///     supported.
+/// Use a custom separator for parameter assignment.<br/>
+/// When <paramref name="allowSpaced"/> is <c>true</c>, the format <c>--param value</c> will also be accepted.<br/>
+/// Otherwise <c>'--param&lt;separator&gt;arg'</c> or <c>'--param key&lt;separator&gt;value'</c> are accepted.<br/>
 /// </summary>
+/// <remarks>
+/// Unified attribute that subsumes the six legacy predecessors: <c>CustomAssignment</c>,
+/// <c>EqualsAssignment</c>, <c>ColonAssignment</c> and the <c>*OrSpaced</c> attributes.<br/>
+/// </remarks>
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 type AssignmentAttribute (separator : string, allowSpaced : bool) =
     inherit Attribute ()
     new (separator : string) = AssignmentAttribute(separator, false)
     /// The assignment separator string (e.g. "=" or ":").
     member _.Separator = separator
-    /// When <c>true</c>, the spaced form is also accepted alongside the separator form.
+    /// When <c>true</c>, the spaced form (<c>--param value</c>) is also accepted alongside the separator form (only supported for non-keyed parameters).
     member _.AllowSpaced = allowSpaced
 
 /// Use a custom separator for parameter assignment.

--- a/src/Argu/Parsers/Cli.fs
+++ b/src/Argu/Parsers/Cli.fs
@@ -196,7 +196,7 @@ let rec private parseCommandLinePartial (state : CliParseState) (argInfo : Union
         handleMainCommandOrUnrecognized state argInfo aggregator token
     | GroupedParams(_, switches) ->
         handleGroupedParams argInfo aggregator switches
-    | CliParam(_, _, caseInfo, Assignment(name,sep,_)) when caseInfo.Arity <> 1 ->
+    | CliParam(_, _, caseInfo, Assignment(name, sep, _)) when caseInfo.Arity <> 1 ->
         error argInfo ErrorCode.CommandLine "invalid CLI syntax '%s%s<param>'." name sep
     | CliParam(token, name, caseInfo, assignment) ->
         handleCliParam state argInfo aggregator token name caseInfo assignment

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -320,37 +320,37 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None -> CliPosition.Unspecified)
 
     let customAssignmentSeparator : Lazy<CustomAssignmentSeparator option> = lazy(
-        let unified = tryGetAttribute2<AssignmentAttribute> attrs declaringTypeAttrs
+        let unified = tryGetAttribute2<SeparatorAttribute> attrs declaringTypeAttrs
 #nowarn 44
         let customAssignment = tryGetAttribute2<CustomAssignmentAttribute> attrs declaringTypeAttrs
         let spaceOrCustomAssignment = tryGetAttribute2<CustomAssignmentOrSpacedAttribute> attrs declaringTypeAttrs
 #warnon 44
         let validateCustomAssignmentAttributes attributeName tolerateSpacedArguments =
             if isMainCommand.Value && types.Length = 1 then
-                arguExn "parameter '%O' of arity 1 contains incompatible attributes '%s' and 'MainCommand'." uci attributeName
+                arguExn "parameter '%O' has incompatible attributes '%s' and 'MainCommand'." uci attributeName
             elif types.Length <> 1 && tolerateSpacedArguments then
-                arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 only." uci attributeName types.Length
+                arguExn "parameter '%O' has '%s' attribute but specifies %d parameters; only 1 permitted." uci attributeName types.Length
             elif types.Length <> 1 && types.Length <> 2 then
-                arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 or 2." uci attributeName types.Length
+                arguExn "parameter '%O' has '%s' attribute but specifies %d parameters; only 1 or 2 permitted." uci attributeName types.Length
             elif isRest then
-                arguExn "parameter '%O' contains incompatible attributes '%s' and 'Rest'." uci attributeName
+                arguExn "parameter '%O' has incompatible attributes '%s' and 'Rest'." uci attributeName
         let handle attributeName sep tolerateSpacedArguments =
             validateCustomAssignmentAttributes attributeName tolerateSpacedArguments
             validateSeparator uci sep
             Some { Separator = sep; TolerateSpacedArguments = tolerateSpacedArguments }
         match unified, customAssignment, spaceOrCustomAssignment with
         | Some unified, None, None ->
-            handle "Assignment" unified.Separator unified.AllowSpaced
+            handle "Separator" unified.Separator unified.OrSpace
         // Unified attribute is preferred; mixing it with the legacy ones is rejected so we don't have to define a merge policy.
         | Some _, _, _ ->
-            arguExn "parameter '%O' mixes the 'Assignment' attribute with a legacy assignment attribute (CustomAssignment / EqualsAssignment / ColonAssignment / *OrSpaced). Use one or the other, not both." uci
+            arguExn "parameter '%O' has 'Separator' attribute, but also a conflicting legacy assignment attribute (CustomAssignment / EqualsAssignment / ColonAssignment / *OrSpaced)." uci
         | None, Some customAssignment, None ->
 #nowarn 44
             let sep = customAssignment.Separator
 #warnon 44
             handle "CustomAssignment" sep (*tolerateSpacedArguments*)false
         | None, Some _, Some _ ->
-            arguExn "parameter '%O' contains incompatible attributes 'CustomAssignment' and 'EitherSpaceOrCustomAssignment'." uci
+            arguExn "parameter '%O' has conflicting attributes 'CustomAssignment' and 'EitherSpaceOrCustomAssignment'." uci
         | None, None, Some spaceOrCustomAssignment ->
 #nowarn 44
             let sep = spaceOrCustomAssignment.Separator
@@ -361,7 +361,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
     let isGatherUnrecognized = lazy(
         if hasAttribute<GatherUnrecognizedAttribute> attrs then
             match types with
-            | _ when isMainCommand.Value -> arguExn "parameter '%O' contains incompatible combination of attributes 'MainCommand' and 'GatherUnrecognized'." uci
+            | _ when isMainCommand.Value -> arguExn "parameter '%O' has conflicting 'MainCommand' and 'GatherUnrecognized' attributes." uci
             | [|t|] when t = typeof<string> -> true
             | _ -> arguExn "parameter '%O' has GatherUnrecognized attribute but specifies invalid parameters. Must contain single parameter of type string." uci
         else
@@ -390,15 +390,15 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
     let checkSubCommand() =
         if Option.isSome customAssignmentSeparator.Value then
-            arguExn "CustomAssignment in '%O' not supported in subcommands." uci
+            arguExn "CustomAssignment in '%O' not supported for subcommands." uci
         if isRest then
-            arguExn "Rest attribute in '%O' not supported in subcommands." uci
+            arguExn "Rest attribute in '%O' not supported for subcommands." uci
         if isMandatory then
-            arguExn "Mandatory attribute in '%O' not supported in subcommands." uci
+            arguExn "Mandatory attribute in '%O' not supported for subcommands." uci
         if isMainCommand.Value then
-            arguExn "MainCommand attribute in '%O' not supported in subcommands." uci
+            arguExn "MainCommand attribute in '%O' not supported for subcommands." uci
         if isInherited then
-            arguExn "Inherit attribute in '%O' not supported in subcommands." uci
+            arguExn "Inherit attribute in '%O' not supported for subcommands." uci
 
     // Children need access to parent levels, but parent levels can't be created until child layers visited ...
     let mutable current : UnionCaseArgInfo option = None
@@ -418,10 +418,10 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
         | [|Optional t|] ->
             if isRest then
-                arguExn "Rest attribute in '%O' not supported in optional parameters." uci
+                arguExn "Rest attribute in '%O' not supported for optional parameters." uci
 
             if isMainCommand.Value then
-                arguExn "MainCommand attribute in '%O' not supported in optional parameters." uci
+                arguExn "MainCommand attribute in '%O' not supported for optional parameters." uci
 
             let label = tryExtractUnionParameterLabel fields[0]
 

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -390,7 +390,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
     let checkSubCommand() =
         if Option.isSome customAssignmentSeparator.Value then
-            arguExn "CustomAssignment in '%O' not supported for subcommands." uci
+            arguExn "Separator attribute in '%O' not supported for subcommands." uci
         if isRest then
             arguExn "Rest attribute in '%O' not supported for subcommands." uci
         if isMandatory then
@@ -429,7 +429,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
         | [|List t|] ->
             if Option.isSome customAssignmentSeparator.Value then
-                arguExn "CustomAssignment in '%O' not supported for list parameters." uci
+                arguExn "Separator attribute in '%O' not supported for list parameters." uci
 
             if isRest then
                 arguExn "Rest attribute in '%O' not supported for list parameters." uci

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -325,8 +325,10 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
 
     let customAssignmentSeparator : Lazy<CustomAssignmentSeparator option> = lazy(
         let unified = tryGetAttribute2<AssignmentAttribute> attrs declaringTypeAttrs
+#nowarn 44
         let customAssignment = tryGetAttribute2<CustomAssignmentAttribute> attrs declaringTypeAttrs
         let spaceOrCustomAssignment = tryGetAttribute2<CustomAssignmentOrSpacedAttribute> attrs declaringTypeAttrs
+#warnon 44
         let validateCustomAssignmentAttributes attributeName tolerateSpacedArguments =
             if isMainCommand.Value && types.Length = 1 then
                 arguExn "parameter '%O' of arity 1 contains incompatible attributes '%s' and 'MainCommand'." uci attributeName
@@ -350,9 +352,12 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None, Some customAssignment, None ->
             let tolerateSpacedArguments = false
             validateCustomAssignmentAttributes "CustomAssignment" tolerateSpacedArguments
-            validateSeparator uci customAssignment.Separator
+#nowarn 44
+            let sep = customAssignment.Separator
+#warnon 44
+            validateSeparator uci sep
             {
-                Separator = customAssignment.Separator
+                Separator = sep
                 TolerateSpacedArguments = tolerateSpacedArguments
             }
             |> Some
@@ -361,9 +366,12 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None, None, Some spaceOrCustomAssignment ->
             let tolerateSpacedArguments = true
             validateCustomAssignmentAttributes "EitherSpaceOrCustomAssignment" tolerateSpacedArguments
-            validateSeparator uci spaceOrCustomAssignment.Separator
+#nowarn 44
+            let sep = spaceOrCustomAssignment.Separator
+#warnon 44
+            validateSeparator uci sep
             {
-                Separator = spaceOrCustomAssignment.Separator
+                Separator = sep
                 TolerateSpacedArguments = tolerateSpacedArguments
             }
             |> Some

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -223,57 +223,53 @@ let getHierarchy (uai : UnionArgInfo) =
 module Helpers =
     /// recognizes and extracts grouped switches
     /// e.g. -efx --> -e -f -x
-    let groupedSwitchRegex (caseInfo: Lazy<UnionCaseArgInfo[]>) (inheritedParams: Lazy<UnionCaseArgInfo[]>) (helpParam: HelpParam) =
-        lazy(
-            let chars =
-                caseInfo.Value
-                |> Seq.append inheritedParams.Value
-                |> Seq.collect (fun c -> c.CommandLineNames)
-                |> Seq.append helpParam.Flags
-                |> Seq.filter (fun name -> name.Length = 2 && name[0] = '-' && Char.IsLetterOrDigit name[1])
-                |> Seq.map (fun name -> name[1])
-                |> Seq.distinct
-                |> Seq.toArray
-                |> String
+    let groupedSwitchRegex (caseInfo: UnionCaseArgInfo[]) (inheritedParams: UnionCaseArgInfo[]) (helpParam: HelpParam) =
+        let chars =
+            caseInfo
+            |> Seq.append inheritedParams
+            |> Seq.collect (fun c -> c.CommandLineNames)
+            |> Seq.append helpParam.Flags
+            |> Seq.filter (fun name -> name.Length = 2 && name[0] = '-' && Char.IsLetterOrDigit name[1])
+            |> Seq.map (fun name -> name[1])
+            |> Seq.distinct
+            |> Seq.toArray
+            |> String
 
-            if chars.Length = 0 then None else
+        if chars.Length = 0 then None else
 
-            let regex = "^-[" + chars + "]+$"
-            Some regex)
+        let regex = "^-[" + chars + "]+$"
+        Some regex
 
-    let groupedSwitchExtractor (regexString: Lazy<string option>) =
-        lazy(
-            match regexString.Value with
-            | None -> (fun _ -> [||])
-            | Some regexString ->
-                let regex = Regex(regexString, RegexOptions.Compiled)
-                (fun (arg : string) ->
-                    if not <| regex.IsMatch arg then [||]
-                    else Array.init (arg.Length - 1) (fun i -> String([|'-'; arg[i + 1]|]))))
+    let groupedSwitchExtractor (regexString: string option) =
+        match regexString with
+        | None -> (fun _ -> [||])
+        | Some regexString ->
+            let regex = Regex(regexString, RegexOptions.Compiled)
+            (fun (arg : string) ->
+                if not <| regex.IsMatch arg then [||]
+                else Array.init (arg.Length - 1) (fun i -> String([|'-'; arg[i + 1]|])))
 
     let caseCtor uci = FSharpValue.PreComputeUnionConstructor(uci, allBindings)
-    let fieldReader uci = lazy FSharpValue.PreComputeUnionReader(uci, allBindings)
+    let fieldReader uci = FSharpValue.PreComputeUnionReader(uci, allBindings)
 
     let tupleConstructor (types: Type[]) =
-        lazy(
-            match types.Length with
-            | 0 -> fun _ -> arguExn "internal error: attempting to call tuple constructor on nullary case."
-            | 1 -> fun (o:obj[]) -> o[0]
-            | _ ->
-                let tupleType = FSharpType.MakeTupleType types
-                FSharpValue.PreComputeTupleConstructor tupleType)
+        match types.Length with
+        | 0 -> fun _ -> arguExn "internal error: attempting to call tuple constructor on nullary case."
+        | 1 -> fun (o:obj[]) -> o[0]
+        | _ ->
+            let tupleType = FSharpType.MakeTupleType types
+            FSharpValue.PreComputeTupleConstructor tupleType
 
-    let assignParser (customAssignmentSeparator: Lazy<CustomAssignmentSeparator option>) =
-        lazy(
-            match customAssignmentSeparator.Value with
-            | None -> arguExn "internal error: attempting to call assign parser on invalid parameter."
-            | Some {Separator = sep} ->
-                let pattern = @"^(.+)" + (Regex.Escape sep) + "(.+)$"
-                let regex = Regex(pattern, RegexOptions.RightToLeft ||| RegexOptions.Compiled)
-                fun token ->
-                    let m = regex.Match token
-                    if m.Success then Assignment(m.Groups[1].Value, sep, m.Groups[2].Value)
-                    else NoAssignment)
+    let assignParser (customAssignmentSeparator: CustomAssignmentSeparator option) =
+        match customAssignmentSeparator with
+        | None -> arguExn "internal error: attempting to call assign parser on invalid parameter."
+        | Some {Separator = sep} ->
+            let pattern = @"^(.+)" + (Regex.Escape sep) + "(.+)$"
+            let regex = Regex(pattern, RegexOptions.RightToLeft ||| RegexOptions.Compiled)
+            fun token ->
+                let m = regex.Match token
+                if m.Success then Assignment(m.Groups[1].Value, sep, m.Groups[2].Value)
+                else NoAssignment
 
 /// generate argument parsing schema from given UnionCaseInfo
 let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : HelpParam option)
@@ -495,9 +491,9 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | _ when Option.isSome appSettingsName -> appSettingsName.Value
         | _ -> arguExn "parameter '%O' needs to have at least one parse source." uci
 
-    let fieldReader = Helpers.fieldReader uci
-    let fieldCtor = Helpers.tupleConstructor types
-    let assignParser = Helpers.assignParser customAssignmentSeparator
+    let fieldReader = lazy Helpers.fieldReader uci
+    let fieldCtor = lazy Helpers.tupleConstructor types
+    let assignParser = lazy Helpers.assignParser customAssignmentSeparator.Value
 
     if isAppSettingsCSV && fields.Length <> 1 then
         arguExn "CSV attribute is only compatible with branches of unary fields."
@@ -626,7 +622,7 @@ and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpPar
         | [|mcp|] -> Some mcp
         | _ -> arguExn "template type '%O' has specified the MainCommand attribute in more than one union cases." t)
 
-    let groupedSwitchRegex = Helpers.groupedSwitchRegex caseInfo inheritedParams helpParam
+    let groupedSwitchRegex = lazy Helpers.groupedSwitchRegex caseInfo.Value inheritedParams.Value helpParam
 
     let result = {
         Type = t
@@ -638,7 +634,7 @@ and private preComputeUnionArgInfoInner (stack : Type list) (helpParam : HelpPar
         ContainsSubcommands = containsSubcommands
         IsRequiredSubcommand = isRequiredSubcommand
         GroupedSwitchRegex = groupedSwitchRegex
-        GroupedSwitchExtractor = Helpers.groupedSwitchExtractor groupedSwitchRegex
+        GroupedSwitchExtractor = lazy Helpers.groupedSwitchExtractor groupedSwitchRegex.Value
         AppSettingsParamIndex = appSettingsIndex
         InheritedParams = inheritedParams
         CliParamIndex = cliIndex

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -324,6 +324,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         | None -> CliPosition.Unspecified)
 
     let customAssignmentSeparator : Lazy<CustomAssignmentSeparator option> = lazy(
+        let unified = tryGetAttribute2<AssignmentAttribute> attrs declaringTypeAttrs
         let customAssignment = tryGetAttribute2<CustomAssignmentAttribute> attrs declaringTypeAttrs
         let spaceOrCustomAssignment = tryGetAttribute2<CustomAssignmentOrSpacedAttribute> attrs declaringTypeAttrs
         let validateCustomAssignmentAttributes attributeName tolerateSpacedArguments =
@@ -335,8 +336,18 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
                 arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 or 2." uci attributeName types.Length
             elif isRest then
                 arguExn "parameter '%O' contains incompatible attributes '%s' and 'Rest'." uci attributeName
-        match customAssignment, spaceOrCustomAssignment with
-        | Some customAssignment, None ->
+        match unified, customAssignment, spaceOrCustomAssignment with
+        // The new unified attribute wins; mixing it with the legacy ones is rejected so
+        // we don't have to define a merge policy.
+        | Some unified, None, None ->
+            let tolerateSpacedArguments = unified.AllowSpaced
+            validateCustomAssignmentAttributes "Assignment" tolerateSpacedArguments
+            validateSeparator uci unified.Separator
+            { Separator = unified.Separator; TolerateSpacedArguments = tolerateSpacedArguments }
+            |> Some
+        | Some _, _, _ ->
+            arguExn "parameter '%O' mixes the new 'Assignment' attribute with one of the legacy 'CustomAssignment*' attributes. Use one or the other, not both." uci
+        | None, Some customAssignment, None ->
             let tolerateSpacedArguments = false
             validateCustomAssignmentAttributes "CustomAssignment" tolerateSpacedArguments
             validateSeparator uci customAssignment.Separator
@@ -345,9 +356,9 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
                 TolerateSpacedArguments = tolerateSpacedArguments
             }
             |> Some
-        | Some _, Some _ ->
+        | None, Some _, Some _ ->
             arguExn "parameter '%O' contains incompatible attributes 'CustomAssignment' and 'EitherSpaceOrCustomAssignment'." uci
-        | None, Some spaceOrCustomAssignment ->
+        | None, None, Some spaceOrCustomAssignment ->
             let tolerateSpacedArguments = true
             validateCustomAssignmentAttributes "EitherSpaceOrCustomAssignment" tolerateSpacedArguments
             validateSeparator uci spaceOrCustomAssignment.Separator
@@ -356,7 +367,7 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
                 TolerateSpacedArguments = tolerateSpacedArguments
             }
             |> Some
-        | None, None -> None
+        | None, None, None -> None
         )
 
     let isGatherUnrecognized = lazy(

--- a/src/Argu/PreCompute.fs
+++ b/src/Argu/PreCompute.fs
@@ -332,51 +332,35 @@ let rec private preComputeUnionCaseArgInfo (stack : Type list) (helpParam : Help
         let validateCustomAssignmentAttributes attributeName tolerateSpacedArguments =
             if isMainCommand.Value && types.Length = 1 then
                 arguExn "parameter '%O' of arity 1 contains incompatible attributes '%s' and 'MainCommand'." uci attributeName
-            if types.Length <> 1 && tolerateSpacedArguments then
+            elif types.Length <> 1 && tolerateSpacedArguments then
                 arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 only." uci attributeName types.Length
-            if types.Length <> 1 && types.Length <> 2 then
+            elif types.Length <> 1 && types.Length <> 2 then
                 arguExn "parameter '%O' has %s attribute but specifies %d parameters. Should be 1 or 2." uci attributeName types.Length
             elif isRest then
                 arguExn "parameter '%O' contains incompatible attributes '%s' and 'Rest'." uci attributeName
+        let handle attributeName sep tolerateSpacedArguments =
+            validateCustomAssignmentAttributes attributeName tolerateSpacedArguments
+            validateSeparator uci sep
+            Some { Separator = sep; TolerateSpacedArguments = tolerateSpacedArguments }
         match unified, customAssignment, spaceOrCustomAssignment with
-        // The new unified attribute wins; mixing it with the legacy ones is rejected so
-        // we don't have to define a merge policy.
         | Some unified, None, None ->
-            let tolerateSpacedArguments = unified.AllowSpaced
-            validateCustomAssignmentAttributes "Assignment" tolerateSpacedArguments
-            validateSeparator uci unified.Separator
-            { Separator = unified.Separator; TolerateSpacedArguments = tolerateSpacedArguments }
-            |> Some
+            handle "Assignment" unified.Separator unified.AllowSpaced
+        // Unified attribute is preferred; mixing it with the legacy ones is rejected so we don't have to define a merge policy.
         | Some _, _, _ ->
-            arguExn "parameter '%O' mixes the new 'Assignment' attribute with one of the legacy 'CustomAssignment*' attributes. Use one or the other, not both." uci
+            arguExn "parameter '%O' mixes the 'Assignment' attribute with a legacy assignment attribute (CustomAssignment / EqualsAssignment / ColonAssignment / *OrSpaced). Use one or the other, not both." uci
         | None, Some customAssignment, None ->
-            let tolerateSpacedArguments = false
-            validateCustomAssignmentAttributes "CustomAssignment" tolerateSpacedArguments
 #nowarn 44
             let sep = customAssignment.Separator
 #warnon 44
-            validateSeparator uci sep
-            {
-                Separator = sep
-                TolerateSpacedArguments = tolerateSpacedArguments
-            }
-            |> Some
+            handle "CustomAssignment" sep (*tolerateSpacedArguments*)false
         | None, Some _, Some _ ->
             arguExn "parameter '%O' contains incompatible attributes 'CustomAssignment' and 'EitherSpaceOrCustomAssignment'." uci
         | None, None, Some spaceOrCustomAssignment ->
-            let tolerateSpacedArguments = true
-            validateCustomAssignmentAttributes "EitherSpaceOrCustomAssignment" tolerateSpacedArguments
 #nowarn 44
             let sep = spaceOrCustomAssignment.Separator
 #warnon 44
-            validateSeparator uci sep
-            {
-                Separator = sep
-                TolerateSpacedArguments = tolerateSpacedArguments
-            }
-            |> Some
-        | None, None, None -> None
-        )
+            handle "EitherSpaceOrCustomAssignment" sep (*tolerateSpacedArguments*)true
+        | None, None, None -> None)
 
     let isGatherUnrecognized = lazy(
         if hasAttribute<GatherUnrecognizedAttribute> attrs then

--- a/src/Argu/Types.fs
+++ b/src/Argu/Types.fs
@@ -162,7 +162,7 @@ type ArgumentCaseInfo =
         IsMainCommand : bool
         /// If specified, should consume remaining tokens from the CLI
         IsRest : Lazy<bool>
-        /// Separator token used for EqualsAssignment syntax; e.g. '=' forces '--param=arg' syntax
+        /// Separator token used for assignment syntax; e.g. '=' forces '--param=arg' syntax
         CustomAssignmentSeparator : Lazy<CustomAssignmentSeparator option>
         /// If specified, multiple parameters can be added in AppSettings in CSV form.
         AppSettingsCSV : Lazy<bool>

--- a/src/Argu/UnionArgInfo.fs
+++ b/src/Argu/UnionArgInfo.fs
@@ -56,7 +56,7 @@ type UnionCaseArgInfo =
         Name : string
         /// Contextual depth of current argument w.r.t subcommands
         Depth : int
-        /// Numbers of parameters in the given union case
+        /// Numbers of values in the given union case, i.e. a tuple is 2
         Arity : int
         /// Same as UnionCaseInfo.Tag
         Tag : int
@@ -91,7 +91,7 @@ type UnionCaseArgInfo =
         /// Configuration parsing split options
         AppSettingsSplitOptions : StringSplitOptions
 
-        /// Separator token used for EqualsAssignment syntax; e.g. '=' forces '--param=arg' syntax
+        /// Separator token used for Value Assignment syntax; e.g. '=' forces '--param=arg' syntax
         CustomAssignmentSeparator : Lazy<CustomAssignmentSeparator option>
         /// Reads assignment for that specific value
         AssignmentParser : Lazy<string -> Assignment>

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="CoverageTests.fs"/>
     <Compile Include="ParseConfigTests.fs"/>
     <Compile Include="UsageStringsTests.fs"/>
+    <Compile Include="AssignmentAttributeTests.fs"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>

--- a/tests/Argu.Tests/Argu.Tests.fsproj
+++ b/tests/Argu.Tests/Argu.Tests.fsproj
@@ -9,7 +9,7 @@
     <Compile Include="CoverageTests.fs"/>
     <Compile Include="ParseConfigTests.fs"/>
     <Compile Include="UsageStringsTests.fs"/>
-    <Compile Include="AssignmentAttributeTests.fs"/>
+    <Compile Include="SeparatorAttributeTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Argu\Argu.fsproj"/>

--- a/tests/Argu.Tests/AssignmentAttributeTests.fs
+++ b/tests/Argu.Tests/AssignmentAttributeTests.fs
@@ -1,0 +1,103 @@
+namespace Argu.Tests
+
+#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+
+open Xunit
+open Swensen.Unquote
+
+open Argu
+
+/// Tests for the unified [<Assignment>] attribute (PR 27).
+module ``Argu Tests AssignmentAttribute`` =
+
+    // --- Unified [<Assignment>] forms ---
+
+    type EqualsViaNewAttr =
+        | [<Assignment("=")>] Port of int
+        interface IArgParserTemplate with member this.Usage = "x"
+
+    type ColonSpacedViaNewAttr =
+        | [<Assignment(":", allowSpaced = true)>] Tag of string
+        interface IArgParserTemplate with member this.Usage = "x"
+
+    // --- Legacy attributes for parity comparison ---
+
+    type EqualsViaLegacy =
+        | [<EqualsAssignment>] Port of int
+        interface IArgParserTemplate with member this.Usage = "x"
+
+    type ColonSpacedViaLegacy =
+        | [<ColonAssignmentOrSpaced>] Tag of string
+        interface IArgParserTemplate with member this.Usage = "x"
+
+    // --- Equals tests ---
+
+    [<Fact>]
+    let ``[<Assignment("=")>] parses --port=8080`` () =
+        let parser = ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
+        let r = parser.ParseCommandLine([| "--port=8080" |], raiseOnUsage = false)
+        test <@ r.GetResult(EqualsViaNewAttr.Port) = 8080 @>
+
+    [<Fact>]
+    let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
+        let parser = ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
+        let raised =
+            try parser.ParseCommandLine([| "--port"; "8080" |], raiseOnUsage = false) |> ignore ; false
+            with :? ArguParseException -> true
+        test <@ raised @>
+
+    [<Fact>]
+    let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
+        let novel =
+            ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
+                .ParseCommandLine([| "--port=42" |], raiseOnUsage = false)
+                .GetResult(EqualsViaNewAttr.Port)
+        let legacy =
+            ArgumentParser.Create<EqualsViaLegacy>(programName = "app")
+                .ParseCommandLine([| "--port=42" |], raiseOnUsage = false)
+                .GetResult(EqualsViaLegacy.Port)
+        test <@ novel = legacy @>
+
+    // --- Colon-or-spaced tests ---
+
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
+        let parser = ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
+        let r = parser.ParseCommandLine([| "--tag:hello" |], raiseOnUsage = false)
+        test <@ r.GetResult(ColonSpacedViaNewAttr.Tag) = "hello" @>
+
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
+        let parser = ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
+        let r = parser.ParseCommandLine([| "--tag"; "hello" |], raiseOnUsage = false)
+        test <@ r.GetResult(ColonSpacedViaNewAttr.Tag) = "hello" @>
+
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
+        let novel =
+            ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
+                .ParseCommandLine([| "--tag"; "v" |], raiseOnUsage = false)
+                .GetResult(ColonSpacedViaNewAttr.Tag)
+        let legacy =
+            ArgumentParser.Create<ColonSpacedViaLegacy>(programName = "app")
+                .ParseCommandLine([| "--tag"; "v" |], raiseOnUsage = false)
+                .GetResult(ColonSpacedViaLegacy.Tag)
+        test <@ novel = legacy @>
+
+    // --- Conflict detection ---
+
+    type ConflictingAttrs =
+        | [<Assignment("=")>] [<CustomAssignment("=")>] Port of int
+        interface IArgParserTemplate with member this.Usage = "x"
+
+    [<Fact>]
+    let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
+        let raised =
+            try
+                ArgumentParser.Create<ConflictingAttrs>(programName = "app") |> ignore
+                None
+            with :? ArguException as e -> Some e.Message
+        match raised with
+        | None -> failwith "expected ArguException for mixed Assignment + CustomAssignment"
+        | Some msg ->
+            test <@ msg.Contains "Assignment" @>

--- a/tests/Argu.Tests/AssignmentAttributeTests.fs
+++ b/tests/Argu.Tests/AssignmentAttributeTests.fs
@@ -5,104 +5,163 @@ open Xunit
 
 open Argu
 
-// --- Unified [<Assignment>] forms ---
+let run<'T when 'T :> IArgParserTemplate> argv = ArgumentParser.Create<'T>().ParseCommandLine argv
 
-type EqualsViaNewAttr =
-    | [<Assignment("=")>] Port of int
-    interface IArgParserTemplate with member this.Usage = "x"
+module Equals =
 
-type ColonSpacedViaNewAttr =
-    | [<Assignment(":", allowSpaced = true)>] Tag of string
-    interface IArgParserTemplate with member this.Usage = "x"
+    type EqualsViaNewAttr =
+        | [<Assignment("=")>] Port of int
+        interface IArgParserTemplate with member this.Usage = ""
 
-// --- Legacy attributes for parity comparison ---
+    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    type EqualsViaLegacy =
+        | [<EqualsAssignment>] Port of int
+        interface IArgParserTemplate with member this.Usage = "x"
+    #warnon 44
 
-#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
-type EqualsViaLegacy =
-    | [<EqualsAssignment>] Port of int
-    interface IArgParserTemplate with member this.Usage = "x"
+    [<Fact>]
+    let ``[<Assignment("=")>] parses --port=8080`` () =
+        let r = run<EqualsViaNewAttr> [| "--port=8080" |]
+        test <@ r.GetResult EqualsViaNewAttr.Port = 8080 @>
 
-type ColonSpacedViaLegacy =
-    | [<ColonAssignmentOrSpaced>] Tag of string
-    interface IArgParserTemplate with member this.Usage = "x"
-#warnon 44
+    [<Fact>]
+    let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
+        raises<ArguParseException>
+            <@ run<EqualsViaNewAttr>([| "--port"; "8080" |]) @>
 
-// --- Equals tests ---
+    [<Fact>]
+    let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
+        let novel = run<EqualsViaNewAttr> [| "--port=42" |] |> _.GetResult(EqualsViaNewAttr.Port)
+        let legacy = run<EqualsViaLegacy> [| "--port=42" |] |> _.GetResult(EqualsViaLegacy.Port)
+        test <@ novel = legacy @>
 
-let run<'T when 'T :> IArgParserTemplate> args = ArgumentParser.Create<'T>().ParseCommandLine args
+module ColonOrSpaced =
 
-[<Fact>]
-let ``[<Assignment("=")>] parses --port=8080`` () =
-    let r = run<EqualsViaNewAttr> [| "--port=8080" |]
-    test <@ r.GetResult EqualsViaNewAttr.Port = 8080 @>
+    type ColonSpacedViaNewAttr =
+        | [<Assignment(":", allowSpaced = true)>] Tag of string
+        interface IArgParserTemplate with member this.Usage = ""
 
-[<Fact>]
-let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
-    raises<ArguParseException>
-        <@ run<EqualsViaNewAttr>([| "--port"; "8080" |]) @>
+    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    type ColonSpacedViaLegacy =
+        | [<ColonAssignmentOrSpaced>] Tag of string
+        interface IArgParserTemplate with member this.Usage = "x"
+    #warnon 44
 
-[<Fact>]
-let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
-    let novel = run<EqualsViaNewAttr> [| "--port=42" |] |> _.GetResult(EqualsViaNewAttr.Port)
-    let legacy = run<EqualsViaLegacy> [| "--port=42" |] |> _.GetResult(EqualsViaLegacy.Port)
-    test <@ novel = legacy @>
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
+        let r = run<ColonSpacedViaNewAttr> [| "--tag:hello" |]
+        test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
-// --- Colon-or-spaced tests ---
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
+        let r = run<ColonSpacedViaNewAttr> [| "--tag"; "hello" |]
+        test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
-[<Fact>]
-let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
-    let r = run<ColonSpacedViaNewAttr> [| "--tag:hello" |]
-    test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
+    [<Fact>]
+    let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
+        let novel = run<ColonSpacedViaNewAttr> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaNewAttr.Tag)
+        let legacy = run<ColonSpacedViaLegacy> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaLegacy.Tag)
+        test <@ novel = legacy @>
 
-[<Fact>]
-let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
-    let r = run<ColonSpacedViaNewAttr> [| "--tag"; "hello" |]
-    test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
+module LegacyValidations =
 
-[<Fact>]
-let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
-    let novel = run<ColonSpacedViaNewAttr> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaNewAttr.Tag)
-    let legacy = run<ColonSpacedViaLegacy> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaLegacy.Tag)
-    test <@ novel = legacy @>
+    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    type ConflictingAttrs =
+        | [<Assignment "=">] [<CustomAssignment "=">] Port of int
+        interface IArgParserTemplate with member this.Usage = "x"
+    type DisallowedAssignmentArgs =
+        | [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
+        interface IArgParserTemplate with
+            member a.Usage =
+                match a with
+                | Flex_Equals_Assignment _ -> "Disallowed attribute combination"
+    type DisallowedArityWithAssignmentOrSpaced =
+        | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string * int
+        interface IArgParserTemplate with
+            member a.Usage =
+                match a with
+                | Flex_Equals_Assignment _ -> "Disallowed attribute / arity combination"
+    #warnon 44
 
-// --- Conflict detection ---
+    [<Fact>]
+    let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
+        raisesWith<ArguException>
+            <@ ArgumentParser.Create<ConflictingAttrs>() @>
+            (fun e -> <@ e.Message.Contains "mixes the 'Assignment' attribute" @>)
 
-#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
-type ConflictingAttrs =
-    | [<Assignment("=")>] [<CustomAssignment("=")>] Port of int
-    interface IArgParserTemplate with member this.Usage = "x"
-#warnon 44
+    [<Fact>]
+    let ``Disallowed equals assignment combination throws`` () =
+        raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedAssignmentArgs>() @>
 
-[<Fact>]
-let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
-    raisesWith<ArguException>
-        <@ ArgumentParser.Create<ConflictingAttrs>() @>
-        (fun e -> <@ e.Message.Contains "mixes the 'Assignment' attribute" @>)
+    [<Fact>]
+    let ``EqualsAssignmentOrSpaced and arity not one combination throws`` () =
+        raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedArityWithAssignmentOrSpaced>() @>
 
-// --- Legacy tests prior to introduction of AssignmentAttribute ---
+// Moved from Tests.fs; TODO some duplication needs removing
+module Assignment =
 
-#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
-type DisallowedAssignmentArgs =
-| [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
-    interface IArgParserTemplate with
-        member a.Usage =
-            match a with
-            | Flex_Equals_Assignment _ -> "Disallowed attribute combination"
-#warnon 44
+    open Argu.Tests.Main
 
-[<Fact>]
-let ``Disallowed equals assignment combination throws`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedAssignmentArgs>() @>
+    let run argv = parser.Parse(argv, ignoreMissing = true)
 
-#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
-type DisallowedArityWithAssignmentOrSpaced =
-| [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string * int
-    interface IArgParserTemplate with
-        member a.Usage =
-            match a with
-            | Flex_Equals_Assignment _ -> "Disallowed attribute / arity combination"
-#warnon 44
+    [<Fact>]
+    let ``Parse colon assignment 1`` () =
+        let res = run [| "--assignment:foobar" |]
+        test <@ res.GetResult Assignment = "foobar" @>
 
-[<Fact>]
-let ``EqualsAssignmentOrSpaced and arity not one combination throws`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedArityWithAssignmentOrSpaced>() @>
+    [<Fact>]
+    let ``Parse colon assignment 2`` () =
+        let arg = [ Assignment "foo bar" ]
+        let res = parser.PrintCommandLineArguments arg |> run
+        test <@ res.GetResult Assignment = "foo bar" @>
+
+    [<Fact>]
+    let ``Parse key-value equals assignment`` () =
+        let arg = [ Env("foo", "bar") ]
+        let res = parser.PrintCommandLineArguments arg |> run
+        test <@ res.GetResult Env = ("foo", "bar") @>
+
+    [<Fact>]
+    let ``Parse key-value equals assignment 2`` () =
+        let res = run [|"--env"; "foo==bar"|]
+        test <@ res.GetResult Env = ("foo", "=bar") @>
+
+    [<Fact>]
+    let ``Parse equals assignment`` () =
+        let res = run [|"--dir=../../my-relative-path"|]
+        test <@ res.GetResult Dir = "../../my-relative-path" @>
+
+    [<Fact>]
+    let ``Parse equals assignment 2`` () =
+        let res = run [|"--dir==foo"|]
+        test <@ res.GetResult Dir = "=foo" @>
+
+    [<Fact>]
+    let ``Parse equals or space assignment with equals`` () =
+        let res = run [|"--flex-equals-assignment=../../my-relative-path"; "--dir==foo"|]
+        test <@ res.GetResult Flex_Equals_Assignment = "../../my-relative-path" @>
+
+    [<Fact>]
+    let ``Parse equals or space assignment with colon fails`` () =
+        raises<ArguParseException> <@ run [|"--flex-equals-assignment:../../my-relative-path"; "--dir==foo"|] @>
+
+    [<Fact>]
+    let ``Parse equals or space assignment with space`` () =
+        let res = run [|"--flex-equals-assignment"; "../../my-relative-path"; "--dir==foo"|]
+        test <@ res.GetResult Flex_Equals_Assignment = "../../my-relative-path" @>
+
+    [<Fact>]
+    let ``Parse equals or space assignment with space and optional type`` () =
+        let res = run [|"--flex-equals-assignment-with-option"; "../../my-relative-path"; "--dir==foo"|]
+        test <@ res.GetResult Flex_Equals_Assignment_With_Option = Some "../../my-relative-path" @>
+
+    [<Fact>]
+    let ``Parse colon or space assignment with colon`` () =
+        // No need to test space assignment or assignment failure, as EitherSpaceOrEqualsAssignmentAttribute and
+        // EitherSpaceOrColonAssignmentAttribute share the same underlying implementation.
+        let res = run [|"--flex-colon-assignment:../../my-relative-path"; "--dir==foo"|]
+        test <@ res.GetResult Flex_Colon_Assignment = "../../my-relative-path" @>
+
+    [<Fact>]
+    let ``Should fail on incorrect assignment 1`` () =
+        raises<ArguParseException> <@ run [|"--dir:foo"|] @>

--- a/tests/Argu.Tests/AssignmentAttributeTests.fs
+++ b/tests/Argu.Tests/AssignmentAttributeTests.fs
@@ -1,103 +1,108 @@
-namespace Argu.Tests
+module Argu.Tests.AssignmentAttributeTests
 
-#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
-
-open Xunit
 open Swensen.Unquote
+open Xunit
 
 open Argu
 
-/// Tests for the unified [<Assignment>] attribute (PR 27).
-module ``Argu Tests AssignmentAttribute`` =
+// --- Unified [<Assignment>] forms ---
 
-    // --- Unified [<Assignment>] forms ---
+type EqualsViaNewAttr =
+    | [<Assignment("=")>] Port of int
+    interface IArgParserTemplate with member this.Usage = "x"
 
-    type EqualsViaNewAttr =
-        | [<Assignment("=")>] Port of int
-        interface IArgParserTemplate with member this.Usage = "x"
+type ColonSpacedViaNewAttr =
+    | [<Assignment(":", allowSpaced = true)>] Tag of string
+    interface IArgParserTemplate with member this.Usage = "x"
 
-    type ColonSpacedViaNewAttr =
-        | [<Assignment(":", allowSpaced = true)>] Tag of string
-        interface IArgParserTemplate with member this.Usage = "x"
+// --- Legacy attributes for parity comparison ---
 
-    // --- Legacy attributes for parity comparison ---
+#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+type EqualsViaLegacy =
+    | [<EqualsAssignment>] Port of int
+    interface IArgParserTemplate with member this.Usage = "x"
 
-    type EqualsViaLegacy =
-        | [<EqualsAssignment>] Port of int
-        interface IArgParserTemplate with member this.Usage = "x"
+type ColonSpacedViaLegacy =
+    | [<ColonAssignmentOrSpaced>] Tag of string
+    interface IArgParserTemplate with member this.Usage = "x"
+#warnon 44
 
-    type ColonSpacedViaLegacy =
-        | [<ColonAssignmentOrSpaced>] Tag of string
-        interface IArgParserTemplate with member this.Usage = "x"
+// --- Equals tests ---
 
-    // --- Equals tests ---
+let run<'T when 'T :> IArgParserTemplate> args = ArgumentParser.Create<'T>().ParseCommandLine args
 
-    [<Fact>]
-    let ``[<Assignment("=")>] parses --port=8080`` () =
-        let parser = ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
-        let r = parser.ParseCommandLine([| "--port=8080" |], raiseOnUsage = false)
-        test <@ r.GetResult(EqualsViaNewAttr.Port) = 8080 @>
+[<Fact>]
+let ``[<Assignment("=")>] parses --port=8080`` () =
+    let r = run<EqualsViaNewAttr> [| "--port=8080" |]
+    test <@ r.GetResult EqualsViaNewAttr.Port = 8080 @>
 
-    [<Fact>]
-    let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
-        let parser = ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
-        let raised =
-            try parser.ParseCommandLine([| "--port"; "8080" |], raiseOnUsage = false) |> ignore ; false
-            with :? ArguParseException -> true
-        test <@ raised @>
+[<Fact>]
+let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
+    raises<ArguParseException>
+        <@ run<EqualsViaNewAttr>([| "--port"; "8080" |]) @>
 
-    [<Fact>]
-    let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
-        let novel =
-            ArgumentParser.Create<EqualsViaNewAttr>(programName = "app")
-                .ParseCommandLine([| "--port=42" |], raiseOnUsage = false)
-                .GetResult(EqualsViaNewAttr.Port)
-        let legacy =
-            ArgumentParser.Create<EqualsViaLegacy>(programName = "app")
-                .ParseCommandLine([| "--port=42" |], raiseOnUsage = false)
-                .GetResult(EqualsViaLegacy.Port)
-        test <@ novel = legacy @>
+[<Fact>]
+let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
+    let novel = run<EqualsViaNewAttr> [| "--port=42" |] |> _.GetResult(EqualsViaNewAttr.Port)
+    let legacy = run<EqualsViaLegacy> [| "--port=42" |] |> _.GetResult(EqualsViaLegacy.Port)
+    test <@ novel = legacy @>
 
-    // --- Colon-or-spaced tests ---
+// --- Colon-or-spaced tests ---
 
-    [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
-        let parser = ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
-        let r = parser.ParseCommandLine([| "--tag:hello" |], raiseOnUsage = false)
-        test <@ r.GetResult(ColonSpacedViaNewAttr.Tag) = "hello" @>
+[<Fact>]
+let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
+    let r = run<ColonSpacedViaNewAttr> [| "--tag:hello" |]
+    test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
-    [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
-        let parser = ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
-        let r = parser.ParseCommandLine([| "--tag"; "hello" |], raiseOnUsage = false)
-        test <@ r.GetResult(ColonSpacedViaNewAttr.Tag) = "hello" @>
+[<Fact>]
+let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
+    let r = run<ColonSpacedViaNewAttr> [| "--tag"; "hello" |]
+    test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
-    [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
-        let novel =
-            ArgumentParser.Create<ColonSpacedViaNewAttr>(programName = "app")
-                .ParseCommandLine([| "--tag"; "v" |], raiseOnUsage = false)
-                .GetResult(ColonSpacedViaNewAttr.Tag)
-        let legacy =
-            ArgumentParser.Create<ColonSpacedViaLegacy>(programName = "app")
-                .ParseCommandLine([| "--tag"; "v" |], raiseOnUsage = false)
-                .GetResult(ColonSpacedViaLegacy.Tag)
-        test <@ novel = legacy @>
+[<Fact>]
+let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
+    let novel = run<ColonSpacedViaNewAttr> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaNewAttr.Tag)
+    let legacy = run<ColonSpacedViaLegacy> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaLegacy.Tag)
+    test <@ novel = legacy @>
 
-    // --- Conflict detection ---
+// --- Conflict detection ---
 
-    type ConflictingAttrs =
-        | [<Assignment("=")>] [<CustomAssignment("=")>] Port of int
-        interface IArgParserTemplate with member this.Usage = "x"
+#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+type ConflictingAttrs =
+    | [<Assignment("=")>] [<CustomAssignment("=")>] Port of int
+    interface IArgParserTemplate with member this.Usage = "x"
+#warnon 44
 
-    [<Fact>]
-    let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
-        let raised =
-            try
-                ArgumentParser.Create<ConflictingAttrs>(programName = "app") |> ignore
-                None
-            with :? ArguException as e -> Some e.Message
-        match raised with
-        | None -> failwith "expected ArguException for mixed Assignment + CustomAssignment"
-        | Some msg ->
-            test <@ msg.Contains "Assignment" @>
+[<Fact>]
+let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<ConflictingAttrs>() @>
+        (fun e -> <@ e.Message.Contains "mixes the 'Assignment' attribute" @>)
+
+// --- Legacy tests prior to introduction of AssignmentAttribute ---
+
+#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+type DisallowedAssignmentArgs =
+| [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
+    interface IArgParserTemplate with
+        member a.Usage =
+            match a with
+            | Flex_Equals_Assignment _ -> "Disallowed attribute combination"
+#warnon 44
+
+[<Fact>]
+let ``Disallowed equals assignment combination throws`` () =
+    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedAssignmentArgs>() @>
+
+#nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+type DisallowedArityWithAssignmentOrSpaced =
+| [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string * int
+    interface IArgParserTemplate with
+        member a.Usage =
+            match a with
+            | Flex_Equals_Assignment _ -> "Disallowed attribute / arity combination"
+#warnon 44
+
+[<Fact>]
+let ``EqualsAssignmentOrSpaced and arity not one combination throws`` () =
+    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedArityWithAssignmentOrSpaced>() @>

--- a/tests/Argu.Tests/CoverageTests.fs
+++ b/tests/Argu.Tests/CoverageTests.fs
@@ -29,22 +29,22 @@ let run<'T when 'T :> IArgParserTemplate> argv = ArgumentParser.Create<'T>().Par
 let ``ErrorCode.CommandLine: unrecognized argument message`` () =
     raisesWith<ArguParseException>
         <@ run<SimpleArgs> [| "--bogus" |] @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
-                     && e.FirstLine = "ERROR: unrecognized argument: '--bogus'." @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
+                        && e.FirstLine = "ERROR: unrecognized argument: '--bogus'." @>
 
 [<Fact>]
 let ``ErrorCode.PostProcess: missing mandatory message`` () =
     raisesWith<ArguParseException>
         <@ run<SimpleArgs> [||] @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
-                     && e.FirstLine = "ERROR: missing parameter '--port'." @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                     && e.FirstLine = "ERROR: missing parameter '--port'." @>
 
 [<Fact>]
 let ``ErrorCode.CommandLine: missing argument value message`` () =
     raisesWith<ArguParseException>
         <@ run<SimpleArgs> [| "--port" |] @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
-                     && e.FirstLine.StartsWith "ERROR: argument '--port' must be followed by" @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
+                     && e.FirstLine.StartsWith "ERROR: argument '--port' must be followed by" @>
 
 // === Deep (3-level) subcommand mandatory-missing ===
 
@@ -73,9 +73,9 @@ type Level1Args =
 let ``Deep subcommand: mandatory at level 3 missing surfaces in error`` () =
     raisesWith<ArguParseException>
         <@ run<Level1Args> [| "level2"; "level3" |] @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
-                     // 'inner' is the deepest mandatory; its name should appear in the message.
-                     && e.Message.Contains "--inner" @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                        // 'inner' is the deepest mandatory; its name should appear in the message.
+                        && e.Message.Contains "--inner" @>
 
 [<Fact>]
 let ``Deep subcommand: providing the leaf mandatory parses cleanly`` () =
@@ -118,10 +118,10 @@ let ``AppSettings: missing mandatory key raises`` () =
     let parser = ArgumentParser.Create<AppSettingsArgs>()
     raisesWith<ArguParseException>
         <@ parser.ParseConfiguration(reader, ignoreMissing = false) @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
-                     // Argu reports the CLI name in the missing-mandatory error, not the
-                     // AppSettings key. The CLI name is auto-derived ("requiredkey").
-                     && e.Message.Contains "--requiredkey" @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                        // Argu reports the CLI name in the missing-mandatory error, not the
+                        // AppSettings key. The CLI name is auto-derived ("requiredkey").
+                        && e.Message.Contains "--requiredkey" @>
 
 [<Fact>]
 let ``AppSettings: null or empty value is treated as absent`` () =
@@ -141,8 +141,8 @@ let ``AppSettings: invalid type-parse raises with key in message`` () =
 
     raisesWith<ArguParseException>
         <@ parser.ParseConfiguration(reader, ignoreMissing = false) @>
-        (fun e -> <@ e.ErrorCode = ErrorCode.AppSettings
-                     && e.Message.Contains "int-key" @>)
+        <| fun e -> <@ e.ErrorCode = ErrorCode.AppSettings
+                        && e.Message.Contains "int-key" @>
 
 [<Fact>]
 let ``AppSettings: ignoreMissing=true skips mandatory check`` () =

--- a/tests/Argu.Tests/CoverageTests.fs
+++ b/tests/Argu.Tests/CoverageTests.fs
@@ -9,17 +9,8 @@ open Xunit
 
 open Argu
 
-[<RequireQualifiedAccess>]
-module Helpers =
-    let parserError (parser : ArgumentParser<'T>) (argv : string []) =
-        try
-            parser.ParseCommandLine(argv, raiseOnUsage = true) |> ignore
-            None
-        with :? ArguParseException as e -> Some (e.ErrorCode, e.Message)
-
-    let firstLine (msg : string) =
-        msg.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries).[0]
-
+type Exception with
+    member inline x.FirstLine = x.Message.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries).[0]
 
 // === Error message exact-text snapshots ===
 
@@ -32,33 +23,28 @@ type SimpleArgs =
             | Port _ -> "port to bind to"
             | Verbose -> "verbose output"
 
+let run<'T when 'T :> IArgParserTemplate> argv = ArgumentParser.Create<'T>().ParseCommandLine argv
+
 [<Fact>]
 let ``ErrorCode.CommandLine: unrecognized argument message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>()
-    match Helpers.parserError parser [| "--bogus" |] with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.CommandLine @>
-        test <@ Helpers.firstLine msg = "ERROR: unrecognized argument: '--bogus'." @>
+    raisesWith<ArguParseException>
+        <@ run<SimpleArgs> [| "--bogus" |] @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
+                     && e.FirstLine = "ERROR: unrecognized argument: '--bogus'." @>)
 
 [<Fact>]
 let ``ErrorCode.PostProcess: missing mandatory message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>()
-    match Helpers.parserError parser [||] with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.PostProcess @>
-        test <@ Helpers.firstLine msg = "ERROR: missing parameter '--port'." @>
+    raisesWith<ArguParseException>
+        <@ run<SimpleArgs> [||] @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                     && e.FirstLine = "ERROR: missing parameter '--port'." @>)
 
 [<Fact>]
 let ``ErrorCode.CommandLine: missing argument value message`` () =
-    let parser = ArgumentParser.Create<SimpleArgs>()
-    match Helpers.parserError parser [| "--port" |] with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.CommandLine @>
-        test <@ (Helpers.firstLine msg).StartsWith "ERROR: argument '--port' must be followed by" @>
-
+    raisesWith<ArguParseException>
+        <@ run<SimpleArgs> [| "--port" |] @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.CommandLine
+                     && e.FirstLine.StartsWith "ERROR: argument '--port' must be followed by" @>)
 
 // === Deep (3-level) subcommand mandatory-missing ===
 
@@ -85,22 +71,19 @@ type Level1Args =
 
 [<Fact>]
 let ``Deep subcommand: mandatory at level 3 missing surfaces in error`` () =
-    let parser = ArgumentParser.Create<Level1Args>()
-    match Helpers.parserError parser [| "level2"; "level3" |] with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.PostProcess @>
-        // 'inner' is the deepest mandatory; its name should appear in the message.
-        test <@ msg.Contains "--inner" @>
+    raisesWith<ArguParseException>
+        <@ run<Level1Args> [| "level2"; "level3" |] @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                     // 'inner' is the deepest mandatory; its name should appear in the message.
+                     && e.Message.Contains "--inner" @>)
 
 [<Fact>]
 let ``Deep subcommand: providing the leaf mandatory parses cleanly`` () =
-    let parser = ArgumentParser.Create<Level1Args>()
-    let results = parser.ParseCommandLine([| "level2"; "level3"; "--inner"; "ok" |], raiseOnUsage = false)
+    let r = run<Level1Args> [| "level2"; "level3"; "--inner"; "ok" |]
     // Probe through the public surface: walk subcommand → subcommand → leaf.
-    let l2 = results.GetResult(Level2)
-    let l3 = l2.GetResult(Level3)
-    test <@ l3.GetResult(Inner) = "ok" @>
+    test <@ let l2 = r.GetResult Level2
+            let l3 = l2.GetResult Level3
+            l3.GetResult Inner = "ok" @>
 
 
 // === AppSettings edge cases ===
@@ -129,27 +112,22 @@ let ``AppSettings: dictionary reader returns parsed value`` () =
 
 [<Fact>]
 let ``AppSettings: missing mandatory key raises`` () =
-    let parser = ArgumentParser.Create<AppSettingsArgs>()
     let dict = Dictionary<string, string>()
     // required-key intentionally absent
     let reader = ConfigurationReader.FromDictionary dict
-    let raised =
-        try parser.ParseConfiguration(reader, ignoreMissing = false) |> ignore ; None
-        with :? ArguParseException as e -> Some (e.ErrorCode, e.Message)
-    match raised with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.PostProcess @>
-        // Argu reports the CLI name in the missing-mandatory error, not the
-        // AppSettings key. The CLI name is auto-derived ("requiredkey").
-        test <@ msg.Contains "--requiredkey" @>
+    let parser = ArgumentParser.Create<AppSettingsArgs>()
+    raisesWith<ArguParseException>
+        <@ parser.ParseConfiguration(reader, ignoreMissing = false) @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.PostProcess
+                     // Argu reports the CLI name in the missing-mandatory error, not the
+                     // AppSettings key. The CLI name is auto-derived ("requiredkey").
+                     && e.Message.Contains "--requiredkey" @>)
 
 [<Fact>]
 let ``AppSettings: null or empty value is treated as absent`` () =
     let parser = ArgumentParser.Create<AppSettingsArgs>()
-    let dict = Dictionary<string, string>()
-    dict["required-key"] <- "x" // satisfy mandatory
-    dict["optional-key"] <- ""   // empty string should be treated as absent
+    let dict = dict [ "required-key", "x"  // satisfy mandatory
+                      "optional-key", "" ] // empty string should be treated as absent
     let reader = ConfigurationReader.FromDictionary dict
     let results = parser.ParseConfiguration(reader, ignoreMissing = false)
     test <@ results.TryGetResult(OptionalKey) = None @>
@@ -157,26 +135,22 @@ let ``AppSettings: null or empty value is treated as absent`` () =
 [<Fact>]
 let ``AppSettings: invalid type-parse raises with key in message`` () =
     let parser = ArgumentParser.Create<AppSettingsArgs>()
-    let dict = Dictionary<string, string>()
-    dict["required-key"] <- "x"
-    dict["int-key"] <- "not-a-number"
+    let dict = dict [ "required-key", "x"
+                      "int-key", "not-a-number" ]
     let reader = ConfigurationReader.FromDictionary dict
-    let raised =
-        try parser.ParseConfiguration(reader, ignoreMissing = false) |> ignore ; None
-        with :? ArguParseException as e -> Some (e.ErrorCode, e.Message)
-    match raised with
-    | None -> failwith "expected parse error"
-    | Some (code, msg) ->
-        test <@ code = ErrorCode.AppSettings @>
-        test <@ msg.Contains "int-key" @>
+
+    raisesWith<ArguParseException>
+        <@ parser.ParseConfiguration(reader, ignoreMissing = false) @>
+        (fun e -> <@ e.ErrorCode = ErrorCode.AppSettings
+                     && e.Message.Contains "int-key" @>)
 
 [<Fact>]
 let ``AppSettings: ignoreMissing=true skips mandatory check`` () =
     let parser = ArgumentParser.Create<AppSettingsArgs>()
-    let reader = ConfigurationReader.FromDictionary(Dictionary<string, string>())
+    let reader = ConfigurationReader.FromDictionary(dict [])
     // Should not raise.
     let results = parser.ParseConfiguration(reader, ignoreMissing = true)
-    test <@ results.TryGetResult(RequiredKey) = None @>
+    test <@ results.TryGetResult RequiredKey = None @>
 
 
 // === Env-var (covers Argu's existing EnvironmentVariableConfigurationReader) ===
@@ -190,11 +164,9 @@ type EnvArgs =
 let ``EnvironmentVariableConfigurationReader: reads process env`` () =
     let key = "ARGU_TEST_VAL"
     let prior = Environment.GetEnvironmentVariable key
-    try
-        Environment.SetEnvironmentVariable(key, "from-env")
+    try Environment.SetEnvironmentVariable(key, "from-env")
         let parser = ArgumentParser.Create<EnvArgs>()
         let reader = ConfigurationReader.FromEnvironmentVariables()
         let results = parser.ParseConfiguration(reader, ignoreMissing = true)
-        test <@ results.GetResult(Val) = "from-env" @>
-    finally
-        Environment.SetEnvironmentVariable(key, prior)
+        test <@ results.GetResult Val = "from-env" @>
+    finally Environment.SetEnvironmentVariable(key, prior)

--- a/tests/Argu.Tests/PrimitiveTests.fs
+++ b/tests/Argu.Tests/PrimitiveTests.fs
@@ -13,15 +13,15 @@ type ArgumentPrimitive =
   | [<Unique>] Unique_Arg of bool
 #nowarn 44 // Obsolete attributes
   | [<Rest; ParseCSV>] Rest_Arg of int
+  | [<ColonAssignment>] Assignment of string
+  | [<EqualsAssignment>] Env of key:string * value:string
+  | [<EqualsAssignment>] Dir of path:string
 #warnon 44
   | [<MainCommand; Last; Unique>] Main of str:string
   | [<Inherit>] Data of int * byte []
   | Log_Level of int
   | [<AltCommandLine("/D", "-D", "-z")>] Detach
   | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
-  | [<ColonAssignment>] Assignment of string
-  | [<EqualsAssignment>] Env of key:string * value:string
-  | [<EqualsAssignment>] Dir of path:string
   | [<First>] First_Parameter of string
   | [<Last>] Last_Parameter of string
   | Optional of int option

--- a/tests/Argu.Tests/PrimitiveTests.fs
+++ b/tests/Argu.Tests/PrimitiveTests.fs
@@ -19,11 +19,9 @@ type ArgumentPrimitive =
     | Log_Level of int
     | [<AltCommandLine("/D", "-D", "-z")>] Detach
     | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
-#nowarn 44 // Obsolete attributes
-    | [<ColonAssignment>] Assignment of string
-    | [<EqualsAssignment>] Env of key:string * value:string
-    | [<EqualsAssignment>] Dir of path:string
-#warnon 44
+    | [<Separator ":">] Assignment of string
+    | [<Separator "=">] Env of key:string * value:string
+    | [<Separator "=">] Dir of path:string
     | [<First>] First_Parameter of string
     | [<Last>] Last_Parameter of string
     | Optional of int option
@@ -50,7 +48,7 @@ type ArgumentPrimitive =
             | List _ -> "variadic params"
             | Optional _ -> "optional params"
 
-let parser = ArgumentParser.Create<ArgumentPrimitive> (programName = "gadget")
+let parser = ArgumentParser.Create<ArgumentPrimitive>(programName = "gadget")
 
 [<Fact>]
 let ``Simple command line parsing`` () =
@@ -71,13 +69,13 @@ let ``Simple command line parsing`` () =
 let ``Help String`` () =
     raisesWith<ArguParseException>
         <@ parser.ParseCommandLine [| "--help" |] @>
-        (fun e -> <@ e.Message.Contains "USAGE:" @>)
+        <| fun e -> <@ e.Message.Contains "USAGE:" @>
 
 [<Fact>]
 let ``First Parameter not placed at beginning`` () =
     raisesWith<ArguParseException>
         <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
-        (fun e -> <@ e.Message.Contains "should precede all other" @>)
+        <| fun e -> <@ e.Message.Contains "should precede all other" @>
 
 [<Fact>]
 let ``Ignore Unrecognized parameters`` () =
@@ -120,7 +118,7 @@ module ``Traps for defaulting and or post-processing functions`` =
             <| fun e -> <@ e.Message = "Defaulting Failed" && e.ErrorCode = ErrorCode.PostProcess @>
         raisesWith<ArguParseException>
             <@ results.GetResult(Working_Directory, failingDefThunk) @>
-            (fun e -> <@ e.Message.StartsWith "Defaulting Failed" && e.Message.Contains "--working-directory" @>)
+            <| fun e -> <@ e.Message.StartsWith "Defaulting Failed" && e.Message.Contains "--working-directory" @>
 
     [<Fact>]
     let ``Trap defaulting function exceptions (for overloads with parse functions)`` () =
@@ -131,7 +129,7 @@ module ``Traps for defaulting and or post-processing functions`` =
             <| fun e -> <@ e.Message = "Defaulting Failed" && e.ErrorCode = ErrorCode.PostProcess @>
         raisesWith<ArguParseException>
             <@ results.GetResult(Working_Directory, failingDefThunk, parser)  @>
-            (fun e -> <@ e.Message.StartsWith "Defaulting Failed" && e.Message.Contains "--working-directory" @>)
+            <| fun e -> <@ e.Message.StartsWith "Defaulting Failed" && e.Message.Contains "--working-directory" @>
 
     [<Fact>]
     let ``Trap post processing exceptions for GetResult overloads with defaulting functions`` () =
@@ -142,7 +140,7 @@ module ``Traps for defaulting and or post-processing functions`` =
             <| fun e -> <@ e.Message = "Parse Failed" && e.ErrorCode = ErrorCode.PostProcess @>
         raisesWith<ArguParseException>
             <@ results.GetResult(Working_Directory, okDefThunk, parser)  @>
-            (fun e -> <@ e.Message.StartsWith "Parse Failed" && e.Message.Contains "--working-directory" @>)
+            <| fun e -> <@ e.Message.StartsWith "Parse Failed" && e.Message.Contains "--working-directory" @>
 
     [<Fact>]
     let ``Trap post processing exceptions for GetResult overloads with default values`` () =
@@ -153,4 +151,4 @@ module ``Traps for defaulting and or post-processing functions`` =
             <| fun e -> <@ e.Message = "Parse Failed" && e.ErrorCode = ErrorCode.PostProcess @>
         raisesWith<ArguParseException>
             <@ results.GetResult(Working_Directory, def, parser)  @>
-            (fun e -> <@ e.Message.StartsWith "Parse Failed" && e.Message.Contains "--working-directory" @>)
+            <| fun e -> <@ e.Message.StartsWith "Parse Failed" && e.Message.Contains "--working-directory" @>

--- a/tests/Argu.Tests/PrimitiveTests.fs
+++ b/tests/Argu.Tests/PrimitiveTests.fs
@@ -6,51 +6,51 @@ open Xunit
 open Argu
 
 type ArgumentPrimitive =
-  | [<AltCommandLine("-v"); Inherit>] Verbose
-  | Working_Directory of string
-  | [<AppSettingsSeparator(':')>] Listener of host:string * port:int
-  | [<Mandatory>] Mandatory_Arg of bool
-  | [<Unique>] Unique_Arg of bool
+    | [<AltCommandLine("-v"); Inherit>] Verbose
+    | Working_Directory of string
+    | [<AppSettingsSeparator(':')>] Listener of host:string * port:int
+    | [<Mandatory>] Mandatory_Arg of bool
+    | [<Unique>] Unique_Arg of bool
 #nowarn 44 // Obsolete attributes
-  | [<Rest; ParseCSV>] Rest_Arg of int
-  | [<ColonAssignment>] Assignment of string
-  | [<EqualsAssignment>] Env of key:string * value:string
-  | [<EqualsAssignment>] Dir of path:string
+    | [<Rest; ParseCSV>] Rest_Arg of int
 #warnon 44
-  | [<MainCommand; Last; Unique>] Main of str:string
-  | [<Inherit>] Data of int * byte []
-  | Log_Level of int
-  | [<AltCommandLine("/D", "-D", "-z")>] Detach
-  | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
-  | [<First>] First_Parameter of string
-  | [<Last>] Last_Parameter of string
-  | Optional of int option
-  | List of int list
-  interface IArgParserTemplate with
-      member a.Usage =
-          match a with
-          | Verbose -> "be verbose."
-          | Working_Directory _ -> "specify a working directory."
-          | Listener _ -> "specify a listener."
-          | Mandatory_Arg _ -> "a mandatory argument."
-          | Unique_Arg _ -> "a unique argument."
-          | Rest_Arg _ -> "an argument that consumes all remaining command line tokens."
-          | Data _ -> "pass raw data in base64 format."
-          | Dir _ -> "Project directory to place the config & database in."
-          | Log_Level _ -> "set the log level."
-          | Detach -> "detach daemon from console."
-          | Assignment _ -> "assign with colon operation."
-          | Env _ -> "assign environment variables."
-          | Main _ -> "main command."
-          | CustomAppConfig _ -> "parameter with custom AppConfig key."
-          | First_Parameter _ -> "parameter that has to appear at beginning of command line args."
-          | Last_Parameter _ -> "parameter that has to appear at end of command line args."
-          | List _ -> "variadic params"
-          | Optional _ -> "optional params"
-
+    | [<MainCommand; Last; Unique>] Main of str:string
+    | [<Inherit>] Data of int * byte []
+    | Log_Level of int
+    | [<AltCommandLine("/D", "-D", "-z")>] Detach
+    | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
+#nowarn 44 // Obsolete attributes
+    | [<ColonAssignment>] Assignment of string
+    | [<EqualsAssignment>] Env of key:string * value:string
+    | [<EqualsAssignment>] Dir of path:string
+#warnon 44
+    | [<First>] First_Parameter of string
+    | [<Last>] Last_Parameter of string
+    | Optional of int option
+    | List of int list
+    interface IArgParserTemplate with
+        member a.Usage =
+            match a with
+            | Verbose -> "be verbose."
+            | Working_Directory _ -> "specify a working directory."
+            | Listener _ -> "specify a listener."
+            | Mandatory_Arg _ -> "a mandatory argument."
+            | Unique_Arg _ -> "a unique argument."
+            | Rest_Arg _ -> "an argument that consumes all remaining command line tokens."
+            | Data _ -> "pass raw data in base64 format."
+            | Dir _ -> "Project directory to place the config & database in."
+            | Log_Level _ -> "set the log level."
+            | Detach -> "detach daemon from console."
+            | Assignment _ -> "assign with colon operation."
+            | Env _ -> "assign environment variables."
+            | Main _ -> "main command."
+            | CustomAppConfig _ -> "parameter with custom AppConfig key."
+            | First_Parameter _ -> "parameter that has to appear at beginning of command line args."
+            | Last_Parameter _ -> "parameter that has to appear at end of command line args."
+            | List _ -> "variadic params"
+            | Optional _ -> "optional params"
 
 let parser = ArgumentParser.Create<ArgumentPrimitive> (programName = "gadget")
-let parseFunc ignoreMissing f = parser.ParseConfiguration(ConfigurationReader.FromFunction f, ignoreMissing)
 
 [<Fact>]
 let ``Simple command line parsing`` () =
@@ -69,13 +69,15 @@ let ``Simple command line parsing`` () =
 
 [<Fact>]
 let ``Help String`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--help" |] @>
-                                    (fun e -> <@ e.Message.Contains "USAGE:" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine [| "--help" |] @>
+        (fun e -> <@ e.Message.Contains "USAGE:" @>)
 
 [<Fact>]
 let ``First Parameter not placed at beginning`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
-                                    (fun e -> <@ e.Message.Contains "should precede all other" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
+        (fun e -> <@ e.Message.Contains "should precede all other" @>)
 
 [<Fact>]
 let ``Ignore Unrecognized parameters`` () =

--- a/tests/Argu.Tests/SeparatorAttributeTests.fs
+++ b/tests/Argu.Tests/SeparatorAttributeTests.fs
@@ -13,7 +13,7 @@ module SeparatorAttributeWithEquals =
         | [<Separator("=")>] Port of int
         interface IArgParserTemplate with member this.Usage = ""
 
-    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    #nowarn 44 // Legacy *Assignment attributes are obsolete; tests deliberately use them.
     type EqualsViaLegacy =
         | [<EqualsAssignment>] Port of int
         interface IArgParserTemplate with member this.Usage = "x"
@@ -41,7 +41,7 @@ module ColonOrSpaced =
         | [<Separator(":", orSpace = true)>] Tag of string
         interface IArgParserTemplate with member this.Usage = ""
 
-    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    #nowarn 44 // Legacy *Assignment attributes are obsolete; tests deliberately use them.
     type ColonSpacedViaLegacy =
         | [<ColonAssignmentOrSpaced>] Tag of string
         interface IArgParserTemplate with member this.Usage = "x"
@@ -65,7 +65,7 @@ module ColonOrSpaced =
 
 module LegacyValidations =
 
-    #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
+    #nowarn 44 // Legacy *Assignment attributes are obsolete; tests deliberately use them.
     type ConflictingAttrs =
         | [<Separator "=">] [<CustomAssignment "=">] Port of int
         interface IArgParserTemplate with member this.Usage = "x"
@@ -105,7 +105,7 @@ module Assignment =
     let run argv = parser.ParseCommandLine(argv, ignoreMissing = true)
 
     [<Fact>]
-    let ``Should fail if assigment with Separator only has no separator.`` () =
+    let ``Should fail if assignment with custom Separator (without `orSpace`) does not contain such a separator.`` () =
         raisesWith<ArguParseException>
             <@ run [|"--assignment"; "value"|] @>
             <| fun e -> <@ e.FirstLine.Contains "missing an assignment" @>

--- a/tests/Argu.Tests/SeparatorAttributeTests.fs
+++ b/tests/Argu.Tests/SeparatorAttributeTests.fs
@@ -1,4 +1,4 @@
-module Argu.Tests.AssignmentAttributeTests
+module Argu.Tests.SeparatorAttributeTests
 
 open Swensen.Unquote
 open Xunit
@@ -7,10 +7,10 @@ open Argu
 
 let run<'T when 'T :> IArgParserTemplate> argv = ArgumentParser.Create<'T>().ParseCommandLine argv
 
-module Equals =
+module SeparatorAttributeWithEquals =
 
     type EqualsViaNewAttr =
-        | [<Assignment("=")>] Port of int
+        | [<Separator("=")>] Port of int
         interface IArgParserTemplate with member this.Usage = ""
 
     #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
@@ -20,25 +20,25 @@ module Equals =
     #warnon 44
 
     [<Fact>]
-    let ``[<Assignment("=")>] parses --port=8080`` () =
+    let ``[<Separator("=")>] parses --port=8080`` () =
         let r = run<EqualsViaNewAttr> [| "--port=8080" |]
         test <@ r.GetResult EqualsViaNewAttr.Port = 8080 @>
 
     [<Fact>]
-    let ``[<Assignment("=")>] rejects --port 8080 (no spaced form)`` () =
+    let ``[<Separator("=")>] rejects --port 8080 (no spaced form)`` () =
         raises<ArguParseException>
             <@ run<EqualsViaNewAttr>([| "--port"; "8080" |]) @>
 
     [<Fact>]
-    let ``[<Assignment("=")>] matches [<EqualsAssignment>] parity`` () =
-        let novel = run<EqualsViaNewAttr> [| "--port=42" |] |> _.GetResult(EqualsViaNewAttr.Port)
-        let legacy = run<EqualsViaLegacy> [| "--port=42" |] |> _.GetResult(EqualsViaLegacy.Port)
+    let ``[<Separator("=")>] matches [<EqualsAssignment>] parity`` () =
+        let novel = let r = run<EqualsViaNewAttr> [| "--port=42" |] in r.GetResult EqualsViaNewAttr.Port
+        let legacy = let r = run<EqualsViaLegacy> [| "--port=42" |] in r.GetResult EqualsViaLegacy.Port
         test <@ novel = legacy @>
 
 module ColonOrSpaced =
 
     type ColonSpacedViaNewAttr =
-        | [<Assignment(":", allowSpaced = true)>] Tag of string
+        | [<Separator(":", orSpace = true)>] Tag of string
         interface IArgParserTemplate with member this.Usage = ""
 
     #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
@@ -48,26 +48,26 @@ module ColonOrSpaced =
     #warnon 44
 
     [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag:value`` () =
+    let ``[<Separator(":", orSpace = true)>] accepts --tag:value`` () =
         let r = run<ColonSpacedViaNewAttr> [| "--tag:hello" |]
         test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
     [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] accepts --tag spaced`` () =
+    let ``[<Separator(":", orSpace = true)>] accepts --tag spaced`` () =
         let r = run<ColonSpacedViaNewAttr> [| "--tag"; "hello" |]
         test <@ r.GetResult ColonSpacedViaNewAttr.Tag = "hello" @>
 
     [<Fact>]
-    let ``[<Assignment(":", allowSpaced = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
-        let novel = run<ColonSpacedViaNewAttr> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaNewAttr.Tag)
-        let legacy = run<ColonSpacedViaLegacy> [| "--tag"; "v" |] |> _.GetResult(ColonSpacedViaLegacy.Tag)
+    let ``[<Separator(":", orSpace = true)>] matches [<ColonAssignmentOrSpaced>] parity`` () =
+        let novel = let r = run<ColonSpacedViaNewAttr> [| "--tag"; "v" |] in r.GetResult ColonSpacedViaNewAttr.Tag
+        let legacy = let r = run<ColonSpacedViaLegacy> [| "--tag"; "v" |] in r.GetResult ColonSpacedViaLegacy.Tag
         test <@ novel = legacy @>
 
 module LegacyValidations =
 
     #nowarn "44" // Legacy *Assignment attributes are obsolete; tests deliberately use them.
     type ConflictingAttrs =
-        | [<Assignment "=">] [<CustomAssignment "=">] Port of int
+        | [<Separator "=">] [<CustomAssignment "=">] Port of int
         interface IArgParserTemplate with member this.Usage = "x"
     type DisallowedAssignmentArgs =
         | [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
@@ -84,10 +84,10 @@ module LegacyValidations =
     #warnon 44
 
     [<Fact>]
-    let ``Mixing [<Assignment>] with legacy CustomAssignment raises a clear error`` () =
+    let ``Mixing [<Separator>] with legacy CustomAssignment raises a clear error`` () =
         raisesWith<ArguException>
             <@ ArgumentParser.Create<ConflictingAttrs>() @>
-            (fun e -> <@ e.Message.Contains "mixes the 'Assignment' attribute" @>)
+            <| fun e -> <@ e.Message.Contains "has 'Separator' attribute, but also" @>
 
     [<Fact>]
     let ``Disallowed equals assignment combination throws`` () =
@@ -102,7 +102,13 @@ module Assignment =
 
     open Argu.Tests.Main
 
-    let run argv = parser.Parse(argv, ignoreMissing = true)
+    let run argv = parser.ParseCommandLine(argv, ignoreMissing = true)
+
+    [<Fact>]
+    let ``Should fail if assigment with Separator only has no separator.`` () =
+        raisesWith<ArguParseException>
+            <@ run [|"--assignment"; "value"|] @>
+            <| fun e -> <@ e.FirstLine.Contains "missing an assignment" @>
 
     [<Fact>]
     let ``Parse colon assignment 1`` () =

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -100,18 +100,18 @@ type Argument =
     | Decimal_Arg of decimal
     | [<AltCommandLine("/D", "-D", "-z")>] Detach
     | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
-    | [<Assignment ":">] Assignment of string
-    | [<Assignment "=">] Env of key:string * value:string
-    | [<Assignment "=">] Dir of path:string
-    | [<Assignment("=", true)>] Flex_Equals_Assignment of string
-    | [<Assignment("=", true)>] Flex_Equals_Assignment_With_Option of string option
-    | [<Assignment(":", true)>] Flex_Colon_Assignment of string
+    | [<Separator ":">] Assignment of string
+    | [<Separator "=">] Env of key:string * value:string
+    | [<Separator "=">] Dir of path:string
+    | [<Separator("=", true)>] Flex_Equals_Assignment of string
+    | [<Separator("=", true)>] Flex_Equals_Assignment_With_Option of string option
+    | [<Separator(":", true)>] Flex_Colon_Assignment of string
     | [<First>] First_Parameter of string
     | [<Last>] Last_Parameter of string
     | Optional of int option
     | List of int list
     | Enum of Enum
-    | [<Assignment "=">] Enumeration of Enumeration option
+    | [<Separator "=">] Enumeration of Enumeration option
     | [<CliPrefix(CliPrefix.Dash)>] A
     | [<CliPrefix(CliPrefix.Dash)>] B
     | [<CliPrefix(CliPrefix.Dash)>] C
@@ -262,13 +262,15 @@ let ``AppSettings List param single`` () =
 
 [<Fact>]
 let ``Help String`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--help" |] @>
-                                    (fun e -> <@ e.Message.Contains "USAGE:" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine [| "--help" |] @>
+        <| fun e -> <@ e.Message.Contains "USAGE:" @>
 
 [<Fact>]
 let ``Missing Mandatory parameter`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "-D" |] @>
-                                    (fun e -> <@ e.FirstLine.Contains "missing parameter" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine [| "-D" |] @>
+        <| fun e -> <@ e.FirstLine.Contains "missing parameter" @>
 
 
 // Test the Turkish dot-less 'i', when converting the capital 'I' in the Union below this
@@ -296,13 +298,15 @@ let ``Unique parameter specified once`` () =
 
 [<Fact>]
 let ``Unique parameter specified twice`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine([| "--unique-arg" ; "true" ; "--unique-arg" ; "false" |], ignoreMissing = true) @>
-                                    (fun e -> <@ e.Message.Contains "more than once" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine([| "--unique-arg" ; "true" ; "--unique-arg" ; "false" |], ignoreMissing = true) @>
+        <| fun e -> <@ e.Message.Contains "more than once" @>
 
 [<Fact>]
 let ``First Parameter not placed at beginning`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
-                                    (fun e -> <@ e.Message.Contains "should precede all other" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine [| "--mandatory-arg" ; "true" ; "--first-parameter" ; "foo" |] @>
+        <| fun e -> <@ e.Message.Contains "should precede all other" @>
 
 
 [<Fact>]
@@ -347,14 +351,16 @@ let ``Ignore Unrecognized parameters`` () =
 [<Fact>]
 let ``Fail on misplaced First parameter`` () =
     let args = [|"--mandatory-arg" ; "true" ; "--first-parameter" ; "arg" |]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                    (fun e -> <@ e.FirstLine.Contains "should precede" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "should precede" @>
 
 [<Fact>]
 let ``Fail on misplaced Last parameter`` () =
     let args = [|"--last-parameter" ; "arg" ; "--mandatory-arg"; "true"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                    (fun e -> <@ e.FirstLine.Contains "should appear after" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "should appear after" @>
 
 [<Fact>]
 let ``Should recognize grouped switches`` () =
@@ -384,30 +390,32 @@ let ``Simple subcommand parsing 2`` () =
 [<Fact>]
 let ``Main command parsing should fail on missing parameters`` () =
     let args = [|"push" ; "origin" |]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                (fun e -> <@ e.FirstLine.Contains "must be followed by <branch name>" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "must be followed by <branch name>" @>
 
 [<Fact>]
 let ``Main command parsing should fail on missing mandatory sub command parameter`` () =
     let args = [|"--mandatory-arg" ; "true" ; "checkout"  |]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                (fun e -> <@ e.FirstLine.Contains "--branch" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "--branch" @>
 
 [<Fact>]
 let ``Main command parsing should fail and display all missing mandatories sub command parameters`` () =
     let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                    (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'." @>
 
 [<Fact>]
 let ``Missing mandatories at parent and subcommand levels are reported together`` () =
     // Subcommand mandatories are missing; the parent's --mandatory-arg is also missing.
     // The error must surface all four names in a single message, not just one group.
     let args = [|"multiple-mandatories" ; "--valuea"; "5"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                    (fun e -> <@ e.FirstLine.Contains "--valueb"
-                                                && e.FirstLine.Contains "--valuec"
-                                                && e.FirstLine.Contains "--mandatory-arg" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "--valueb" && e.FirstLine.Contains "--valuec" && e.FirstLine.Contains "--mandatory-arg" @>
 
 [<Fact>]
 let ``Main command parsing should not fail on missing mandatory sub command parameter if ignoreMissing`` () =
@@ -426,8 +434,9 @@ let ``Main command parsing should allow sub command if not missing mandatory par
 [<Fact>]
 let ``Main command parsing should fail on missing mandatory sub command's sub command parameter`` () =
     let args = [|"--mandatory-arg"; "true"; "tag"; "--new"; |]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                (fun e -> <@ e.FirstLine.Contains "--name" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "--name" @>
 
 [<Fact>]
 let ``Main command parsing should allow trailing arguments`` () =
@@ -440,8 +449,9 @@ let ``Main command parsing should allow trailing arguments`` () =
 [<Fact>]
 let ``Main command parsing should not permit interstitial arguments`` () =
     let args = [|"push" ; "origin" ; "-f" ; "master"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
-                                (fun e -> <@ e.FirstLine.Contains "but was '-f'" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
+        <| fun e -> <@ e.FirstLine.Contains "but was '-f'" @>
 
     let results = parser.ParseCommandLine(args, ignoreMissing = true, ignoreUnrecognized = true)
     let nested = results.GetResult <@ Push @>
@@ -472,8 +482,9 @@ let ``Doubly nested subcommand parsing`` () =
 [<Fact>]
 let ``Required subcommand attribute should fail on missing subcommand`` () =
     let args = [|"required" ; "--foo" |]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
-                                    (fun e -> <@ e.FirstLine.Contains "subcommand" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
+        <| fun e -> <@ e.FirstLine.Contains "subcommand" @>
 
 [<Fact>]
 let ``Nullary subcommand`` () =
@@ -491,8 +502,9 @@ let ``Required subcommand nullary subcommand can be parsed`` () =
 [<Fact>]
 let ``Calling multiple sibling subcommands is not permitted`` () =
     let args = [|"required"; "null-sub"; "sub"; "-fdx"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
-                                    (fun e -> <@ e.FirstLine.Contains "cannot run multiple subcommands" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine(args, ignoreMissing = true) @>
+        <| fun e -> <@ e.FirstLine.Contains "cannot run multiple subcommands" @>
 
 [<Fact>]
 let ``GatherUnrecognized attribute`` () =
@@ -560,8 +572,9 @@ let ``Enumeration parameter parsing (case-insensitive, allowing original case)``
 
 [<Fact>]
 let ``Enumeration parameter should fail on unsupported values`` () =
-    raisesWith<ArguParseException> <@ parser.Parse([|"--enum" ; "first,second" ; "--mandatory-arg" ; "true"|]) @>
-                                    (fun e -> <@ e.FirstLine.Contains "first|second|third" @>)
+    raisesWith<ArguParseException>
+        <@ parser.Parse([|"--enum" ; "first,second" ; "--mandatory-arg" ; "true"|]) @>
+        <| fun e -> <@ e.FirstLine.Contains "first|second|third" @>
 
 [<Fact>]
 let ``F# Enumeration parameter parsing`` () =
@@ -575,8 +588,9 @@ let ``F# Enumeration parameter parsing (case-insensitive, allowing original case
 
 [<Fact>]
 let ``F# Enumeration parameter should fail on unsupported values`` () =
-    raisesWith<ArguParseException> <@ parser.Parse([|"--enumeration=foobar" ; "--mandatory-arg" ; "true"|]) @>
-                                    (fun e -> <@ e.FirstLine.Contains "first|second|third" @>)
+    raisesWith<ArguParseException>
+        <@ parser.Parse([|"--enumeration=foobar" ; "--mandatory-arg" ; "true"|]) @>
+        <| fun e -> <@ e.FirstLine.Contains "first|second|third" @>
 
 [<Fact>]
 let ``List parameter - empty`` () =
@@ -597,7 +611,7 @@ let ``List parameter - multiple args`` () =
 let ``Get all subcommand parsers`` () =
     let subcommands = parser.GetSubCommandParsers()
     test <@ subcommands.Length = 7 @>
-    test <@ subcommands |> List.forall (fun sc -> sc.IsSubCommandParser) @>
+    test <@ subcommands |> List.forall _.IsSubCommandParser @>
 
 [<Fact>]
 let ``Get specific subcommand parser`` () =
@@ -673,28 +687,33 @@ type GenericArgument<'T> =
 
 [<Fact>]
 let ``Identify conflicting CLI identifiers`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<ConflictingCliNames>() @>
-                                (fun e -> <@ e.FirstLine.Contains "conflicting CLI" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<ConflictingCliNames>() @>
+        <| fun e -> <@ e.FirstLine.Contains "conflicting CLI" @>
 
 [<Fact>]
 let ``Identify conflicting inherited CLI identifiers`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<ConflictingInheritedCliName>() @>
-                                (fun e -> <@ e.FirstLine.Contains "conflicting CLI" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<ConflictingInheritedCliName>() @>
+        <| fun e -> <@ e.FirstLine.Contains "conflicting CLI" @>
 
 [<Fact>]
 let ``Identify conflicting AppSettings identifiers`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<ConflictingAppSettingsNames>() @>
-                                (fun e -> <@ e.FirstLine.Contains "conflicting AppSettings" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<ConflictingAppSettingsNames>() @>
+        <| fun e -> <@ e.FirstLine.Contains "conflicting AppSettings" @>
 
 [<Fact>]
 let ``Identify recursive subcommands`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<RecursiveArgument1>() @>
-                                (fun e -> <@ e.FirstLine.Contains "recursive" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<RecursiveArgument1>() @>
+        <| fun e -> <@ e.FirstLine.Contains "recursive" @>
 
 [<Fact>]
 let ``Identify generic arguments`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<GenericArgument<string>>() @>
-                                (fun e -> <@ e.FirstLine.Contains "generic" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<GenericArgument<string>>() @>
+        <| fun e -> <@ e.FirstLine.Contains "generic" @>
 
 type NestedDuplicatesAreOk =
     | [<AltCommandLine("-f")>] Force
@@ -766,11 +785,6 @@ let ``Use no prefix as default`` () =
     test <@ results.GetResult <@ Levels_Deep @> = 3 @>
 
 [<Fact>]
-let ``Should fail if EqualsAssignment missing assignment.`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine([|"--assignment"; "value"|], ignoreMissing = true) @>
-                                    (fun e -> <@ e.FirstLine.Contains "missing an assignment" @>)
-
-[<Fact>]
 let ``Slash in Commandline`` () =
     let args = [| "--mandatory-arg" ; "true" ; "/D" |]
     let results = parser.ParseCommandLine args
@@ -778,8 +792,9 @@ let ``Slash in Commandline`` () =
 
 [<Fact>]
 let ``Should fail when Usage, Mandatory and raiseOnUsage = true`` () =
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine ([|"--help"|], raiseOnUsage = true) @>
-                                    (fun e -> <@ e.FirstLine.Contains "USAGE:" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine ([|"--help"|], raiseOnUsage = true) @>
+        <| fun e -> <@ e.FirstLine.Contains "USAGE:" @>
 
 [<Fact>]
 let ``Usage, Mandatory and raiseOnusage = false`` () =
@@ -790,9 +805,10 @@ let ``Usage, Mandatory and raiseOnusage = false`` () =
 [<Fact>]
 let ``Should fail if mandatory case is missing on a subcommand and display usage of subcommand and not main command`` () =
     let args = [|"--mandatory-arg" ; "true" ;  "multiple-mandatories" ; "--valuea"; "5"|]
-    raisesWith<ArguParseException> <@ parser.ParseCommandLine args @>
-                                    (fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'"
-                                                  && e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>)
+    raisesWith<ArguParseException>
+        <@ parser.ParseCommandLine args @>
+        <| fun e -> <@ e.FirstLine.Contains "ERROR: missing parameter '--valueb', '--valuec'"
+                       && e.Message.Contains $"USAGE: {parser.ProgramName} multiple-mandatories [--help] --valuea <int>" @>
 
 [<HelpFlags("--my-help")>]
 [<HelpDescription("waka jawaka")>]
@@ -840,8 +856,9 @@ type NestedInherited =
 
 [<Fact>]
 let ``Fail on inherited nested union cases`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<NestedInherited>() @>
-                              (fun e -> <@ e.FirstLine.Contains "Inherit" @>)
+    raisesWith<ArguException>
+        <@ ArgumentParser.Create<NestedInherited>() @>
+        <| fun e -> <@ e.FirstLine.Contains "Inherit" @>
 
 [<Fact>]
 let ``Fail on malformed case constructors`` () =

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -394,28 +394,6 @@ let ``Parse colon or space assignment with colon`` () =
     let result = parser.Parse([|"--flex-colon-assignment:../../my-relative-path"; "--dir==foo"|], ignoreMissing = true)
     test <@ result.GetResult Flex_Colon_Assignment = "../../my-relative-path" @>
 
-type DisallowedAssignmentArgs =
-| [<EqualsAssignmentOrSpaced>] [<EqualsAssignment>] Flex_Equals_Assignment of string
-    interface IArgParserTemplate with
-        member a.Usage =
-            match a with
-            | Flex_Equals_Assignment _ -> "Disallowed attribute combination"
-
-[<Fact>]
-let ``Disallowed equals assignment combination throws`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedAssignmentArgs> (programName = "gadget") @>
-
-type DisallowedArityWithAssignmentOrSpaced =
-| [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string * int
-    interface IArgParserTemplate with
-        member a.Usage =
-            match a with
-            | Flex_Equals_Assignment _ -> "Disallowed attribute / arity combination"
-
-[<Fact>]
-let ``EqualsAssignmentOrSpaced and arity not one combination throws`` () =
-    raisesWith<ArguException> <@ ArgumentParser.Create<DisallowedArityWithAssignmentOrSpaced> (programName = "gadget1") @>
-
 [<Fact>]
 let ``Should fail on incorrect assignment 1`` () =
     raises<ArguParseException> <@ parser.Parse([|"--dir:foo"|], ignoreMissing = true) @>

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -100,18 +100,22 @@ type Argument =
     | Decimal_Arg of decimal
     | [<AltCommandLine("/D", "-D", "-z")>] Detach
     | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
+#nowarn 44 // Obsolete attributes
     | [<ColonAssignment>] Assignment of string
     | [<EqualsAssignment>] Env of key:string * value:string
     | [<EqualsAssignment>] Dir of path:string
     | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string
     | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment_With_Option of string option
     | [<ColonAssignmentOrSpaced>] Flex_Colon_Assignment of string
+#warnon 44
     | [<First>] First_Parameter of string
     | [<Last>] Last_Parameter of string
     | Optional of int option
     | List of int list
     | Enum of Enum
+#nowarn 44 // Obsolete attributes
     | [<EqualsAssignment>] Enumeration of Enumeration option
+#warnon 44
     | [<CliPrefix(CliPrefix.Dash)>] A
     | [<CliPrefix(CliPrefix.Dash)>] B
     | [<CliPrefix(CliPrefix.Dash)>] C

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -100,22 +100,18 @@ type Argument =
     | Decimal_Arg of decimal
     | [<AltCommandLine("/D", "-D", "-z")>] Detach
     | [<CustomAppSettings "Foo">] CustomAppConfig of string * int
-#nowarn 44 // Obsolete attributes
-    | [<ColonAssignment>] Assignment of string
-    | [<EqualsAssignment>] Env of key:string * value:string
-    | [<EqualsAssignment>] Dir of path:string
-    | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment of string
-    | [<EqualsAssignmentOrSpaced>] Flex_Equals_Assignment_With_Option of string option
-    | [<ColonAssignmentOrSpaced>] Flex_Colon_Assignment of string
-#warnon 44
+    | [<Assignment ":">] Assignment of string
+    | [<Assignment "=">] Env of key:string * value:string
+    | [<Assignment "=">] Dir of path:string
+    | [<Assignment("=", true)>] Flex_Equals_Assignment of string
+    | [<Assignment("=", true)>] Flex_Equals_Assignment_With_Option of string option
+    | [<Assignment(":", true)>] Flex_Colon_Assignment of string
     | [<First>] First_Parameter of string
     | [<Last>] Last_Parameter of string
     | Optional of int option
     | List of int list
     | Enum of Enum
-#nowarn 44 // Obsolete attributes
-    | [<EqualsAssignment>] Enumeration of Enumeration option
-#warnon 44
+    | [<Assignment "=">] Enumeration of Enumeration option
     | [<CliPrefix(CliPrefix.Dash)>] A
     | [<CliPrefix(CliPrefix.Dash)>] B
     | [<CliPrefix(CliPrefix.Dash)>] C
@@ -332,72 +328,6 @@ let ``Parse byte[] parameters`` () =
     let args = parser.PrintCommandLineArguments [ Mandatory_Arg false ; Data(42, bytes) ]
     let results = parser.ParseCommandLine args
     test <@ let _,bytes' = results.GetResult Data in bytes' = bytes @>
-
-[<Fact>]
-let ``Parse colon assignment 1`` () =
-    let args = [| "--assignment:foobar" |]
-    let result = parser.Parse(args, ignoreMissing = true)
-    test <@ result.GetResult <@ Assignment @> = "foobar" @>
-
-[<Fact>]
-let ``Parse colon assignment 2`` () =
-    let arg = [ Assignment "foo bar" ]
-    let clp = parser.PrintCommandLineArguments arg
-    let result = parser.Parse(clp, ignoreMissing = true)
-    test <@ result.GetResult <@ Assignment @> = "foo bar" @>
-
-[<Fact>]
-let ``Parse key-value equals assignment`` () =
-    let arg = [ Env("foo", "bar") ]
-    let clp = parser.PrintCommandLineArguments arg
-    let result = parser.Parse(clp, ignoreMissing = true)
-    test <@ result.GetResult Env = ("foo", "bar") @>
-
-[<Fact>]
-let ``Parse key-value equals assignment 2`` () =
-    let result = parser.Parse([|"--env"; "foo==bar"|], ignoreMissing = true)
-    test <@ result.GetResult <@ Env @> = ("foo", "=bar") @>
-
-[<Fact>]
-let ``Parse equals assignment`` () =
-    let result = parser.Parse([|"--dir=../../my-relative-path"|], ignoreMissing = true)
-    test <@ result.GetResult Dir = "../../my-relative-path" @>
-
-[<Fact>]
-let ``Parse equals assignment 2`` () =
-    let result = parser.Parse([|"--dir==foo"|], ignoreMissing = true)
-    test <@ result.GetResult Dir = "=foo" @>
-
-[<Fact>]
-let ``Parse equals or space assignment with equals`` () =
-    let result = parser.Parse([|"--flex-equals-assignment=../../my-relative-path"; "--dir==foo"|], ignoreMissing = true)
-    test <@ result.GetResult Flex_Equals_Assignment = "../../my-relative-path" @>
-
-[<Fact>]
-let ``Parse equals or space assignment with colon fails`` () =
-    raises<ArguParseException> <@ parser.Parse([|"--flex-equals-assignment:../../my-relative-path"; "--dir==foo"|], ignoreMissing = true) @>
-
-[<Fact>]
-let ``Parse equals or space assignment with space`` () =
-    let result = parser.Parse([|"--flex-equals-assignment"; "../../my-relative-path"; "--dir==foo"|], ignoreMissing = true)
-    test <@ result.GetResult Flex_Equals_Assignment = "../../my-relative-path" @>
-
-[<Fact>]
-let ``Parse equals or space assignment with space and optional type`` () =
-    let result = parser.Parse([|"--flex-equals-assignment-with-option"; "../../my-relative-path"; "--dir==foo"|], ignoreMissing = true)
-    test <@ result.GetResult Flex_Equals_Assignment_With_Option = Some "../../my-relative-path" @>
-
-[<Fact>]
-let ``Parse colon or space assignment with colon`` () =
-    // No need to test space assignment or assignment failure, as EitherSpaceOrEqualsAssignmentAttribute and
-    // EitherSpaceOrColonAssignmentAttribute share the same underlying implementation.
-    let result = parser.Parse([|"--flex-colon-assignment:../../my-relative-path"; "--dir==foo"|], ignoreMissing = true)
-    test <@ result.GetResult Flex_Colon_Assignment = "../../my-relative-path" @>
-
-[<Fact>]
-let ``Should fail on incorrect assignment 1`` () =
-    raises<ArguParseException> <@ parser.Parse([|"--dir:foo"|], ignoreMissing = true) @>
-
 
 [<Fact>]
 let ``Ignore Unrecognized parameters`` () =

--- a/tests/Argu.Tests/tests.fsx
+++ b/tests/Argu.Tests/tests.fsx
@@ -1,4 +1,4 @@
-﻿#I "bin/Debug/net6.0/"
+﻿#I "bin/Debug/net10.0/"
 #r "Argu.dll"
 #r "Argu.Tests.dll"
 
@@ -49,13 +49,13 @@ type GitArgs =
     | Log_Level of LogLevel
     | [<CliPrefix(CliPrefix.None)>] Push of options:ParseResults<PushArgs>
     | [<CliPrefix(CliPrefix.None)>] Clean of suboptions:ParseResults<CleanArgs>
-    | [<AltCommandLine("-E")>][<EqualsAssignment>] Environment_Variable of key:string * value:string
+    | [<AltCommandLine("-E"); Separator "=">] Environment_Variable of key:string * value:string
     | Ports of tcp_port:int list
     | Optional of num:int option
     | Options of MyEnum option
     | [<Inherit>] Silent
-with 
-    interface IArgParserTemplate with 
+with
+    interface IArgParserTemplate with
         member this.Usage =
             match this with
             | Listener _ -> "Specify a listener host/port combination."


### PR DESCRIPTION
feat(Attributes): Add unified `[<Separator>]`; obsolete the six legacy

* Attributes.fs: New SeparatorAttribute(separator, ?orSpace)
  subsumes CustomAssignment / EqualsAssignment / ColonAssignment /
  CustomAssignmentOrSpaced / EqualsAssignmentOrSpaced /
  ColonAssignmentOrSpaced. The legacy six are now marked [<Obsolete>]
  with a deprecation message pointing at the equivalent
  [<Separator(...)>] invocation. Behavior and storage layout are
  preserved.
* Attributes.fs: Add a file-scoped #nowarn 44 so the legacy attributes
  that derive from now-obsolete bases (EqualsAssignmentAttribute :>
  CustomAssignmentAttribute, etc.) still compile inside this file.
  Callers outside the file still see the obsolete warning.
* PreCompute.fs customAssignmentSeparator: read SeparatorAttributeAttribute
  first; if present it wins. Mixing the new attribute with any of the
  legacy six is rejected with a clear error so we don't have to invent
  a merge policy. The legacy two-attribute matrix is preserved
  byte-identical for callers still using it.

Additive at the compile level; existing code emits deprecation warnings only.

---

testSeparatorAttribute): Coverage for unified [<Separator>] attr

7 new tests:
* [<Separator("=")>] parses --port=8080 and rejects spaced --port 8080.
* [<Separator("=")>] result matches the legacy [<EqualsAssignment>]
  parity case.
* [<Separator(":", orSpace = true)>] accepts both --tag:value and
  --tag value spaced forms.
* Parity with [<ColonAssignmentOrSpaced>].
* Mixing [<Separator>] with the legacy [<CustomAssignment>] on the same
  case raises a clear ArguException whose message mentions Assignment —
  the rejection prevents accidental double-attribution.

Net suite on this branch:
112 -> 119.

---