### PR TITLE
Fix help rendering when usage string empty re #173

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Fix Clarify exception in expr2Uci [#293](https://github.com/fsprojects/Argu/pull/293) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Report all missing args in error message, not just first level [#297](https://github.com/fsprojects/Argu/pull/297) [@dimension-zero](https://github.com/dimension-zero)
 * Fix Limit min wordwrap column to 20 [#302](https://github.com/fsprojects/Argu/pull/302) [@dimension-zero](https://github.com/dimension-zero)
+* Fix [misrendering of usage when help blank](https://github.com/fsprojects/Argu/issues/173) [#323](https://github.com/fsprojects/Argu/pull/323) [@DominikL1999](https://github.com/DominikL1999)
 * Add `Separator("=", orSpace = true)` attribute to replace `EqualsAssignmentAttribute`, `ColonAssignmentAttribute`, `CustomAssignmentAttribute`, `EqualsAssignmentOrSpacedAttribute`, `ColonAssignmentOrSpacedAttribute` and `CustomAssignmentOrSpacedAttribute` [#315](https://github.com/fsprojects/Argu/pull/315) [@dimension-zero](https://github.com/dimension-zero)
 * Add `Argu.Samples.Introspect` sample [#298](https://github.com/fsprojects/Argu/pull/298) [@dimension-zero](https://github.com/dimension-zero)
 * Add `ArgumentParser.Parse(ParseConfig)` [#307](https://github.com/fsprojects/Argu/pull/307) [@dimension-zero](https://github.com/dimension-zero)

--- a/src/Argu/UnParsers.fs
+++ b/src/Argu/UnParsers.fs
@@ -184,7 +184,7 @@ let mkArgUsage width (aI : UnionCaseArgInfo) = stringExpr {
     let lines = wordwrapSafe width aI.Description.Value
 
     match lines with
-    | [] -> ()
+    | [] -> yield Environment.NewLine
     | h :: tail ->
         yield h
         yield Environment.NewLine

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -70,3 +70,50 @@ let ``Custom SubcommandHelpHint replaces the default hint line`` () =
             SubcommandHelpHintFormat = "Tapez '{0} <sous-commande> {1}' pour plus d'informations." }
     let rendered = parser.PrintUsage(usageStrings = labels)
     test <@ rendered.Contains "Tapez 'myapp <sous-commande> --help' pour plus d'informations." @>
+
+type KanjiArgs =
+    | Strokes of int
+    | Min_Strokes of int
+    | Max_Strokes of int
+    | Include_Stroke_Miscounts
+    | Radicals of string
+    | Skip_Code of string
+    | Sh_Code of string
+    | Four_Corner_Code of string
+    | Deroo_Code of string
+    | Reading of string
+    | Nanori of string
+    | Common_Only
+    | Pattern of string
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Strokes _ -> ""
+            | Min_Strokes _ -> ""
+            | Max_Strokes _ -> "20"
+            | Include_Stroke_Miscounts -> "false"
+            | Radicals _ -> ""
+            | Skip_Code _ -> ""
+            | Sh_Code _ -> ""
+            | Four_Corner_Code _ -> "92029"
+            | Deroo_Code _ -> "92381"
+            | Reading _ -> "xsuztlak"
+            | Nanori _ -> ""
+            | Common_Only -> "false"
+            | Pattern _ -> "jjsoowi"
+
+[<Fact>]
+let ``Usage also prints new line for options that have an empty string as usage`` () =
+    let parser = ArgumentParser<KanjiArgs>()
+    let usage = parser.PrintUsage()
+    let lines = usage.Split "\n"
+    let optionsLines: string array = Array.skipWhile(fun s -> not (s.StartsWith "OPTIONS:")) lines
+    let arguments = [|"strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
+          "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern"|]
+    let argumentLines: string array = 
+        arguments
+        |> Array.map (fun argument -> Array.find(fun line -> line.Contains $"--{argument}") optionsLines)
+    printfn "%A" argumentLines
+    // If argumentLines is distinct, then all arguments are in their own line.
+    test <@ Array.distinct argumentLines = argumentLines @>
+    test <@ (Array.distinct argumentLines).Length = arguments.Length @>

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -107,12 +107,8 @@ module Issue173 =
     [<Fact>]
     let ``Usage also prints new line for options that have an empty string as usage`` () =
         let parser = ArgumentParser<KanjiArgs>()
-        let lines = parser.PrintUsage().Split "\n"
-        let optionsLines: string[] = lines |> Array.skipWhile(fun s -> not (s.StartsWith "OPTIONS:"))
-        let args = [|"strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
-                          "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern"|]
-        let argumentLines = [| for a in args -> optionsLines |> Array.find(fun line -> line.Contains $"--{a}") |]
-        let distinctLines = Array.distinct argumentLines
-        // If argumentLines is distinct, then all arguments are in their own line.
-        test <@ distinctLines = argumentLines
-                && distinctLines.Length = args.Length @>
+        let lines = parser.PrintUsage().Split("\n")
+        let optionsLines: string[] = lines |> Array.skipWhile (fun s -> not (s.StartsWith UsageStrings.Default.Options))
+        let args = [| "strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
+                      "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern" |]
+        test <@ args |> Array.forall (fun arg -> optionsLines |> Array.exists _.Contains($"--{arg}")) @>

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -71,49 +71,48 @@ let ``Custom SubcommandHelpHint replaces the default hint line`` () =
     let rendered = parser.PrintUsage(usageStrings = labels)
     test <@ rendered.Contains "Tapez 'myapp <sous-commande> --help' pour plus d'informations." @>
 
-type KanjiArgs =
-    | Strokes of int
-    | Min_Strokes of int
-    | Max_Strokes of int
-    | Include_Stroke_Miscounts
-    | Radicals of string
-    | Skip_Code of string
-    | Sh_Code of string
-    | Four_Corner_Code of string
-    | Deroo_Code of string
-    | Reading of string
-    | Nanori of string
-    | Common_Only
-    | Pattern of string
-    interface IArgParserTemplate with
-        member this.Usage =
-            match this with
-            | Strokes _ -> ""
-            | Min_Strokes _ -> ""
-            | Max_Strokes _ -> "20"
-            | Include_Stroke_Miscounts -> "false"
-            | Radicals _ -> ""
-            | Skip_Code _ -> ""
-            | Sh_Code _ -> ""
-            | Four_Corner_Code _ -> "92029"
-            | Deroo_Code _ -> "92381"
-            | Reading _ -> "xsuztlak"
-            | Nanori _ -> ""
-            | Common_Only -> "false"
-            | Pattern _ -> "jjsoowi"
+module Issue173 =
 
-[<Fact>]
-let ``Usage also prints new line for options that have an empty string as usage`` () =
-    let parser = ArgumentParser<KanjiArgs>()
-    let usage = parser.PrintUsage()
-    let lines = usage.Split "\n"
-    let optionsLines: string array = Array.skipWhile(fun s -> not (s.StartsWith "OPTIONS:")) lines
-    let arguments = [|"strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
-          "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern"|]
-    let argumentLines: string array = 
-        arguments
-        |> Array.map (fun argument -> Array.find(fun line -> line.Contains $"--{argument}") optionsLines)
-    printfn "%A" argumentLines
-    // If argumentLines is distinct, then all arguments are in their own line.
-    test <@ Array.distinct argumentLines = argumentLines @>
-    test <@ (Array.distinct argumentLines).Length = arguments.Length @>
+    type KanjiArgs =
+        | Strokes of int
+        | Min_Strokes of int
+        | Max_Strokes of int
+        | Include_Stroke_Miscounts
+        | Radicals of string
+        | Skip_Code of string
+        | Sh_Code of string
+        | Four_Corner_Code of string
+        | Deroo_Code of string
+        | Reading of string
+        | Nanori of string
+        | Common_Only
+        | Pattern of string
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Strokes _ -> ""
+                | Min_Strokes _ -> ""
+                | Max_Strokes _ -> "20"
+                | Include_Stroke_Miscounts -> "false"
+                | Radicals _ -> ""
+                | Skip_Code _ -> ""
+                | Sh_Code _ -> ""
+                | Four_Corner_Code _ -> "92029"
+                | Deroo_Code _ -> "92381"
+                | Reading _ -> "xsuztlak"
+                | Nanori _ -> ""
+                | Common_Only -> "false"
+                | Pattern _ -> "jjsoowi"
+
+    [<Fact>]
+    let ``Usage also prints new line for options that have an empty string as usage`` () =
+        let parser = ArgumentParser<KanjiArgs>()
+        let lines = parser.PrintUsage().Split "\n"
+        let optionsLines: string[] = lines |> Array.skipWhile(fun s -> not (s.StartsWith "OPTIONS:"))
+        let args = [|"strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
+                          "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern"|]
+        let argumentLines = [| for a in args -> optionsLines |> Array.find(fun line -> line.Contains $"--{a}") |]
+        let distinctLines = Array.distinct argumentLines
+        // If argumentLines is distinct, then all arguments are in their own line.
+        test <@ distinctLines = argumentLines
+                && distinctLines.Length = args.Length @>

--- a/tests/Argu.Tests/UsageStringsTests.fs
+++ b/tests/Argu.Tests/UsageStringsTests.fs
@@ -104,11 +104,20 @@ module Issue173 =
                 | Common_Only -> "false"
                 | Pattern _ -> "jjsoowi"
 
+    let allExpectedArgNames =
+        [| "strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
+           "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern" |]
+
     [<Fact>]
     let ``Usage also prints new line for options that have an empty string as usage`` () =
         let parser = ArgumentParser<KanjiArgs>()
-        let lines = parser.PrintUsage().Split("\n")
-        let optionsLines: string[] = lines |> Array.skipWhile (fun s -> not (s.StartsWith UsageStrings.Default.Options))
-        let args = [| "strokes"; "min-strokes"; "max-strokes"; "include-stroke-miscounts"; "radicals"; "skip-code";
-                      "sh-code"; "four-corner-code"; "deroo-code"; "reading"; "nanori"; "common-only"; "pattern" |]
-        test <@ args |> Array.forall (fun arg -> optionsLines |> Array.exists _.Contains($"--{arg}")) @>
+        let optionsLines =
+            parser.PrintUsage().Split("\n")
+            // Only examine the section after the 'OPTIONS' label
+            |> Array.skipWhile (fun s -> not (s.StartsWith UsageStrings.Default.Options))
+            // Lines are expected to be indented
+            // but the point is that it's not OK for the argument description to be anywhere other than the start of the line
+            |> Array.map _.TrimStart()
+        let hasLineForArg (lines : string[]) (name: string) = lines |> Array.exists _.StartsWith($"--{name}")
+        test <@ let missing = allExpectedArgNames |> Array.filter (hasLineForArg optionsLines >> not)
+                [||] = missing @>


### PR DESCRIPTION
LiteracyFanatic said that if an argument is an empty string, a newline should be printed in the usages, instead of the empty string. He also claimed that if the arguments are all "x", then there are gaps between some lines, but this behavior stems from the fact that the argument name is too long.

resolves: https://github.com/fsprojects/Argu/issues/173